### PR TITLE
per task timeout

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -240,16 +240,20 @@ class Executor(BaseExecutor):
     self._last_lost_check: float = time.time()
 
     self.executor = socket.gethostname()
-    job_metadata = JobMetadata(
-      True,
-      self.config.priority,
-      self.codedir,
-      self.executor,
-      self.config.limits.asdict(),
-      self.config.env,
-    )
-    self._submit_redis_master.set(get_metadata_key(self.submit_queue_id), json.dumps(job_metadata), ex=7*24*60*60)
+    self.update_job_metadata()
 
+  def update_job_metadata(self, **kwargs):
+    job_metadata_kwargs = {
+      'valid': True,
+      'priority': self.config.priority,
+      'codedir': self.codedir,
+      'executor': self.executor,
+      'limits': self.config.limits.asdict(),
+      'env': self.config.env
+    }
+    job_metadata_kwargs.update(kwargs)
+    job_metadata = JobMetadata(**job_metadata_kwargs)
+    self._submit_redis_master.set(get_metadata_key(self.submit_queue_id), json.dumps(job_metadata), ex=7*24*60*60)
 
   def __enter__(self):
     self._shutdown_writer_threads = False
@@ -303,6 +307,10 @@ class Executor(BaseExecutor):
 
   def fmap(self, fn: Callable, *iterables: Iterable[Any], chunksize: int = 1) -> Iterator[Future]:
     assert not self._shutdown_reader_thread, "Cannot submit new tasks after shutdown has started"
+
+    scaled_limits = {**self.config.limits.asdict()}
+    scaled_limits['timeout_seconds'] *= chunksize
+    self.update_job_metadata(limits=scaled_limits)
 
     # Instead of sending the function along with every request, we cache it in redis and send the cache key in its place
     pickled_fn = cloudpickle.dumps(partial(_execute_batch, fn))

--- a/executor.py
+++ b/executor.py
@@ -324,7 +324,8 @@ class Executor(BaseExecutor):
 
   # Worker threads
 
-  def _writer_loop(self, submitted_queue: Queue[Optional[Future]], function_ptr: str, iterables: list[Iterable[Any]], chunksize: int, timeout_seconds: float) -> None:
+  def _writer_loop(self, submitted_queue: Queue[Optional[Future]], function_ptr: str,
+                   iterables: list[Iterable[Any]], chunksize: int, timeout_seconds: float) -> None:
     try:
       args_iterator = zip(*iterables, strict=True)
       assert chunksize >= 1
@@ -381,7 +382,8 @@ class Executor(BaseExecutor):
           for future in futures:
             future.set_exception(MinirayError("RuntimeError", "task lost", "", ""))
 
-  def _pack_task(self, function_ptr: str, pickled_fn: bytes, args: Sequence[Any], kwargs: dict[str, Any], task_uuid: str, timeout_seconds: float) -> tuple[str, bytes]:
+  def _pack_task(self, function_ptr: str, pickled_fn: bytes, args: Sequence[Any],
+                 kwargs: dict[str, Any], task_uuid: str, timeout_seconds: float) -> tuple[str, bytes]:
     pickled_args = cloudpickle.dumps((args, kwargs))
     if len(pickled_fn) + len(pickled_args) > MAX_ARG_STRLEN:
       raise RuntimeError(f"Can't send target, size ({len(pickled_fn) + len(pickled_args)}) exceeds max allowed length ({MAX_ARG_STRLEN})")

--- a/executor.py
+++ b/executor.py
@@ -243,8 +243,17 @@ class Executor(BaseExecutor):
     self.update_job_metadata()
 
   def update_job_metadata(self, **kwargs):
-    base = JobMetadata(True, self.config.priority, self.codedir, self.executor, self.config.limits.asdict(), self.config.env)
-    self._submit_redis_master.set(get_metadata_key(self.submit_queue_id), json.dumps(base._replace(**kwargs)), ex=7*24*60*60)
+    job_metadata_kwargs = {
+      'valid': True,
+      'priority': self.config.priority,
+      'codedir': self.codedir,
+      'executor': self.executor,
+      'limits': self.config.limits.asdict(),
+      'env': self.config.env
+    }
+    job_metadata_kwargs.update(kwargs)
+    job_metadata = JobMetadata(**job_metadata_kwargs)
+    self._submit_redis_master.set(get_metadata_key(self.submit_queue_id), json.dumps(job_metadata), ex=7*24*60*60)
 
   def __enter__(self):
     self._shutdown_writer_threads = False
@@ -298,6 +307,7 @@ class Executor(BaseExecutor):
 
   def fmap(self, fn: Callable, *iterables: Iterable[Any], chunksize: int = 1) -> Iterator[Future]:
     assert not self._shutdown_reader_thread, "Cannot submit new tasks after shutdown has started"
+
     scaled_limits = {**self.config.limits.asdict()}
     scaled_limits['timeout_seconds'] *= chunksize
     self.update_job_metadata(limits=scaled_limits)

--- a/executor.py
+++ b/executor.py
@@ -243,17 +243,8 @@ class Executor(BaseExecutor):
     self.update_job_metadata()
 
   def update_job_metadata(self, **kwargs):
-    job_metadata_kwargs = {
-      'valid': True,
-      'priority': self.config.priority,
-      'codedir': self.codedir,
-      'executor': self.executor,
-      'limits': self.config.limits.asdict(),
-      'env': self.config.env
-    }
-    job_metadata_kwargs.update(kwargs)
-    job_metadata = JobMetadata(**job_metadata_kwargs)
-    self._submit_redis_master.set(get_metadata_key(self.submit_queue_id), json.dumps(job_metadata), ex=7*24*60*60)
+    base = JobMetadata(True, self.config.priority, self.codedir, self.executor, self.config.limits.asdict(), self.config.env)
+    self._submit_redis_master.set(get_metadata_key(self.submit_queue_id), json.dumps(base._replace(**kwargs)), ex=7*24*60*60)
 
   def __enter__(self):
     self._shutdown_writer_threads = False
@@ -307,7 +298,6 @@ class Executor(BaseExecutor):
 
   def fmap(self, fn: Callable, *iterables: Iterable[Any], chunksize: int = 1) -> Iterator[Future]:
     assert not self._shutdown_reader_thread, "Cannot submit new tasks after shutdown has started"
-
     scaled_limits = {**self.config.limits.asdict()}
     scaled_limits['timeout_seconds'] *= chunksize
     self.update_job_metadata(limits=scaled_limits)

--- a/executor.py
+++ b/executor.py
@@ -240,20 +240,16 @@ class Executor(BaseExecutor):
     self._last_lost_check: float = time.time()
 
     self.executor = socket.gethostname()
-    self.update_job_metadata()
-
-  def update_job_metadata(self, **kwargs):
-    job_metadata_kwargs = {
-      'valid': True,
-      'priority': self.config.priority,
-      'codedir': self.codedir,
-      'executor': self.executor,
-      'limits': self.config.limits.asdict(),
-      'env': self.config.env
-    }
-    job_metadata_kwargs.update(kwargs)
-    job_metadata = JobMetadata(**job_metadata_kwargs)
+    job_metadata = JobMetadata(
+      True,
+      self.config.priority,
+      self.codedir,
+      self.executor,
+      self.config.limits.asdict(),
+      self.config.env,
+    )
     self._submit_redis_master.set(get_metadata_key(self.submit_queue_id), json.dumps(job_metadata), ex=7*24*60*60)
+
 
   def __enter__(self):
     self._shutdown_writer_threads = False
@@ -307,10 +303,6 @@ class Executor(BaseExecutor):
 
   def fmap(self, fn: Callable, *iterables: Iterable[Any], chunksize: int = 1) -> Iterator[Future]:
     assert not self._shutdown_reader_thread, "Cannot submit new tasks after shutdown has started"
-
-    scaled_limits = {**self.config.limits.asdict()}
-    scaled_limits['timeout_seconds'] *= chunksize
-    self.update_job_metadata(limits=scaled_limits)
 
     # Instead of sending the function along with every request, we cache it in redis and send the cache key in its place
     pickled_fn = cloudpickle.dumps(partial(_execute_batch, fn))

--- a/executor.py
+++ b/executor.py
@@ -79,6 +79,7 @@ class TaskRecord(NamedTuple):
   worker: str
   submitted_at: float
   started_at: float
+  timeout_seconds: float
 
 class JobMetadata(NamedTuple):
   valid: bool
@@ -289,20 +290,22 @@ class Executor(BaseExecutor):
     future: Future = Future()
     task_uuid = str(uuid.uuid4())
     pickled_fn = cloudpickle.dumps(partial(_execute_batch, fn))
-    task = self._pack_task('', pickled_fn, [args], kwargs, task_uuid)
+    timeout_seconds = self.config.limits.timeout_seconds
+    task = self._pack_task('', pickled_fn, [args], kwargs, task_uuid, timeout_seconds)
     self._submit_tasks([task])
     self._futures[task_uuid] = ([future], True)
     return future
 
   def map(self, fn: Callable, *iterables: Iterable[Any], timeout: Optional[float] = None, chunksize: int = 1) -> Iterator[Any]:
     if timeout is not None:
-      raise NotImplementedError("Timeout arg is not supported. Use `fmap` instead to get a timeout per task.")
+      raise NotImplementedError("Timeout arg is not supported.")
     # submit all tasks first, then resolve the results lazily
     futures = list(self.fmap(fn, *iterables, chunksize=chunksize))
     return (future.result() for future in futures)
 
   def fmap(self, fn: Callable, *iterables: Iterable[Any], chunksize: int = 1) -> Iterator[Future]:
     assert not self._shutdown_reader_thread, "Cannot submit new tasks after shutdown has started"
+    timeout_seconds = self.config.limits.timeout_seconds * chunksize
 
     # Instead of sending the function along with every request, we cache it in redis and send the cache key in its place
     pickled_fn = cloudpickle.dumps(partial(_execute_batch, fn))
@@ -310,7 +313,7 @@ class Executor(BaseExecutor):
     self._submit_redis_master.set(function_ptr, pickled_fn, ex=7*24*60*60)
 
     submitted_queue: Queue[Optional[Future]] = Queue()
-    writer_thread = threading.Thread(target=self._writer_loop, args=(submitted_queue, function_ptr, list(iterables), chunksize), daemon=True)
+    writer_thread = threading.Thread(target=self._writer_loop, args=(submitted_queue, function_ptr, list(iterables), chunksize, timeout_seconds), daemon=True)
     writer_thread.start()
     self._writer_threads.append(writer_thread)
     while future := submitted_queue.get():
@@ -321,7 +324,7 @@ class Executor(BaseExecutor):
 
   # Worker threads
 
-  def _writer_loop(self, submitted_queue: Queue[Optional[Future]], function_ptr: str, iterables: list[Iterable[Any]], chunksize: int) -> None:
+  def _writer_loop(self, submitted_queue: Queue[Optional[Future]], function_ptr: str, iterables: list[Iterable[Any]], chunksize: int, timeout_seconds: float) -> None:
     try:
       args_iterator = zip(*iterables, strict=True)
       assert chunksize >= 1
@@ -336,7 +339,7 @@ class Executor(BaseExecutor):
           for future in task_futures[task_uuid]:
             submitted_queue.put(future)
         self._futures.update({task_uuid: (futures, False) for task_uuid, futures in task_futures.items()})  # mark as unsubmitted
-        self._submit_tasks([self._pack_task(function_ptr, b'', args, {}, task_uuid) for task_uuid, args in task_args.items()])
+        self._submit_tasks([self._pack_task(function_ptr, b'', args, {}, task_uuid, timeout_seconds) for task_uuid, args in task_args.items()])
         self._futures.update({task_uuid: (futures, True) for task_uuid, futures in task_futures.items()})  # mark as submitted
 
       submitted_queue.put(None)  # Signal the end of the stream
@@ -378,7 +381,7 @@ class Executor(BaseExecutor):
           for future in futures:
             future.set_exception(MinirayError("RuntimeError", "task lost", "", ""))
 
-  def _pack_task(self, function_ptr: str, pickled_fn: bytes, args: Sequence[Any], kwargs: dict[str, Any], task_uuid: str) -> tuple[str, bytes]:
+  def _pack_task(self, function_ptr: str, pickled_fn: bytes, args: Sequence[Any], kwargs: dict[str, Any], task_uuid: str, timeout_seconds: float) -> tuple[str, bytes]:
     pickled_args = cloudpickle.dumps((args, kwargs))
     if len(pickled_fn) + len(pickled_args) > MAX_ARG_STRLEN:
       raise RuntimeError(f"Can't send target, size ({len(pickled_fn) + len(pickled_args)}) exceeds max allowed length ({MAX_ARG_STRLEN})")
@@ -393,6 +396,7 @@ class Executor(BaseExecutor):
       worker='',
       submitted_at=time.time(),
       started_at=0.0,
+      timeout_seconds=timeout_seconds,
     )
     return (task_uuid, json.dumps(record, ensure_ascii=False).encode('utf-8'))
 

--- a/worker.py
+++ b/worker.py
@@ -261,7 +261,7 @@ class Task:
     if self._done:
       return True
 
-    self._timed_out = time.perf_counter() > self.start_time + self.limits.timeout_seconds
+    self._timed_out = time.perf_counter() > self.start_time + self.task.timeout_seconds
 
     # Wait for the process to terminate
     if self.proc.returncode is None:
@@ -291,7 +291,7 @@ class Task:
 
     # Determine result/error state
     if self._timed_out:
-      self._error = ("TimeoutError", f"TimeoutError: task timed out after {self.limits.timeout_seconds} seconds")
+      self._error = ("TimeoutError", f"TimeoutError: task timed out after {self.task.timeout_seconds} seconds")
     elif self.proc.returncode != 0 and exiting:
       self._error = ("WorkerShutdown", "task killed due to worker shutdown")
     elif self.proc.returncode != 0:
@@ -345,7 +345,7 @@ class Task:
       uuid=self.task_uuid, job=self.job, executor=self.task.executor, function_ptr=self.task.function_ptr,
       pickled_fn='', pickled_args='',
       state=TaskState.DONE, worker=WORKER_ID,
-      submitted_at=0.0, started_at=self.start_time,
+      submitted_at=0.0, started_at=self.start_time, timeout_seconds=self.task.timeout_seconds,
     )
     self.r_master.hsetex(tasks_key, self.task_uuid, json.dumps(done_record), ex=3600)
 
@@ -454,7 +454,7 @@ def get_task(resource_manager: ResourceManager, r_master: StrictRedis,
   record = TaskRecord(*json.loads(task_data))
 
   # Transition pending -> working with TTL = timeout + grace
-  ttl = int(limits.timeout_seconds + MAX_WORKER_LOOP_SECONDS + TASK_TIMEOUT_GRACE_SECONDS)
+  ttl = int(record.timeout_seconds + MAX_WORKER_LOOP_SECONDS + TASK_TIMEOUT_GRACE_SECONDS)
   working_record = record._replace(state=TaskState.WORKING, worker=WORKER_ID, started_at=time.time())
   r_master.hsetex(tasks_key, record.uuid, json.dumps(working_record), ex=ttl)
   resource_manager.rekey(temp_key, record.uuid)


### PR DESCRIPTION
set the timeout on the task, scale it by chunksize when we batch

issue + repro:

```python
import miniray

def slow_task(x):
  import time
  time.sleep(4)
  return x

# chunksize=1: all succeed (4s < 10s timeout per task)
with miniray.Executor(limits={'timeout_seconds': 10}, priority=10) as executor:
  results = miniray.log(list(executor.fmap(slow_task, range(10), chunksize=1)), desc="chunksize=1")
ok = sum(1 for r in results if not isinstance(r, Exception))
print(f"chunksize=1:   {ok}/10 succeeded")

# chunksize=10: all fail (10*4=40s > 10s timeout for the batch)
with miniray.Executor(limits={'timeout_seconds': 10}, priority=10) as executor:
  results = miniray.log(list(executor.fmap(slow_task, range(10), chunksize=10)), desc="chunksize=10")
ok = sum(1 for r in results if not isinstance(r, Exception))
print(f"chunksize=10:  {ok}/10 succeeded")

```