### PR TITLE
added per node pycache

### DIFF
--- a/lib/uv.py
+++ b/lib/uv.py
@@ -25,10 +25,6 @@ def pycache_dir_for_venv(venv_name: str, user_id: int) -> Path:
 
 def sync_venv_cache(codedir: Union[str, Path], user_id: int, venv_name: str):
   venv_dir = base_venv_path(user_id) / venv_name
-  pycache_dir = pycache_dir_for_venv(venv_name, user_id)
-  pycache_dir.mkdir(parents=True, exist_ok=True)
-  os.chown(pycache_dir, user_id, user_id)
-
   sync_cmd = ['uv', 'sync', '--project', codedir, '--frozen']
   if os.getenv('CI'):
     sync_cmd += ['--link-mode', 'symlink'] # hardlinking is slow in docker

--- a/lib/uv.py
+++ b/lib/uv.py
@@ -52,8 +52,7 @@ def cleanup_venvs(user_id: int, keep_venvs: list[str]):
   for venv in base_dir.iterdir():
     if venv.name not in keep_venvs:
       shutil.rmtree(venv)
-      pycache_dir = pycache_dir_for_venv(venv.name, user_id)
-      shutil.rmtree(pycache_dir, ignore_errors=True)
+      shutil.rmtree(pycache_dir_for_venv(venv.name, user_id), ignore_errors=True)
 
 
 def populate_venv_cache_from_disk(venv_cache: LRU[str, str], user_id: int) -> None:

--- a/lib/uv.py
+++ b/lib/uv.py
@@ -20,11 +20,8 @@ def parse_uv_sync_stderr(stderr):
 def base_venv_path(user_id: int):
   return Path(pwd.getpwuid(user_id).pw_dir) / ".job_venvs"
 
-def pycache_base_dir(user_id: int) -> Path:
-  return Path(f"/var/cache/miniray/pycache_{user_id}")
-
 def pycache_dir_for_venv(venv_name: str, user_id: int) -> Path:
-  return pycache_base_dir(user_id) / venv_name
+  return Path(f"/var/cache/miniray/pycache_{user_id}") / venv_name
 
 def sync_venv_cache(codedir: Union[str, Path], user_id: int, venv_name: str):
   venv_dir = base_venv_path(user_id) / venv_name
@@ -59,7 +56,7 @@ def cleanup_venvs(user_id: int, keep_venvs: list[str]):
   for venv in base_dir.iterdir():
     if venv.name not in keep_venvs:
       shutil.rmtree(venv)
-      # also delete the companion local pycache dir when the venv is evicted
+      # also delete the local pycache dir
       pycache_dir = pycache_dir_for_venv(venv.name, user_id)
       shutil.rmtree(pycache_dir, ignore_errors=True)
 

--- a/lib/uv.py
+++ b/lib/uv.py
@@ -20,9 +20,11 @@ def parse_uv_sync_stderr(stderr):
 def base_venv_path(user_id: int):
   return Path(pwd.getpwuid(user_id).pw_dir) / ".job_venvs"
 
+def pycache_base_dir(user_id: int) -> Path:
+  return Path(f"/var/cache/miniray/pycache_{user_id}")
+
 def pycache_dir_for_venv(venv_name: str, user_id: int) -> Path:
-  base = Path(os.getenv("MINIRAY_PYCACHE_DIR", f"/var/cache/miniray/pycache_{user_id}"))
-  return base / venv_name
+  return pycache_base_dir(user_id) / venv_name
 
 def sync_venv_cache(codedir: Union[str, Path], user_id: int, venv_name: str):
   venv_dir = base_venv_path(user_id) / venv_name

--- a/lib/uv.py
+++ b/lib/uv.py
@@ -56,7 +56,6 @@ def cleanup_venvs(user_id: int, keep_venvs: list[str]):
   for venv in base_dir.iterdir():
     if venv.name not in keep_venvs:
       shutil.rmtree(venv)
-      # also delete the local pycache dir
       pycache_dir = pycache_dir_for_venv(venv.name, user_id)
       shutil.rmtree(pycache_dir, ignore_errors=True)
 

--- a/lib/uv.py
+++ b/lib/uv.py
@@ -20,8 +20,16 @@ def parse_uv_sync_stderr(stderr):
 def base_venv_path(user_id: int):
   return Path(pwd.getpwuid(user_id).pw_dir) / ".job_venvs"
 
+def pycache_dir_for_venv(venv_name: str, user_id: int) -> Path:
+  base = Path(os.getenv("MINIRAY_PYCACHE_DIR", f"/var/cache/miniray/pycache_{user_id}"))
+  return base / venv_name
+
 def sync_venv_cache(codedir: Union[str, Path], user_id: int, venv_name: str):
   venv_dir = base_venv_path(user_id) / venv_name
+  pycache_dir = pycache_dir_for_venv(venv_name, user_id)
+  pycache_dir.mkdir(parents=True, exist_ok=True)
+  os.chown(pycache_dir, user_id, user_id)
+
   sync_cmd = ['uv', 'sync', '--project', codedir, '--frozen']
   if os.getenv('CI'):
     sync_cmd += ['--link-mode', 'symlink'] # hardlinking is slow in docker
@@ -49,6 +57,9 @@ def cleanup_venvs(user_id: int, keep_venvs: list[str]):
   for venv in base_dir.iterdir():
     if venv.name not in keep_venvs:
       shutil.rmtree(venv)
+      # also delete the companion local pycache dir when the venv is evicted
+      pycache_dir = pycache_dir_for_venv(venv.name, user_id)
+      shutil.rmtree(pycache_dir, ignore_errors=True)
 
 
 def populate_venv_cache_from_disk(venv_cache: LRU[str, str], user_id: int) -> None:

--- a/worker.py
+++ b/worker.py
@@ -37,7 +37,7 @@ from miniray.lib.triton_helpers import TRITON_SERVER_ADDRESS, check_triton_serve
 from miniray.lib.system_helpers import get_cgroup_cpu_usage, get_cgroup_mem_usage, get_gpu_stats, get_gpu_mem_usage, get_gpu_utilization
 from miniray.lib.statsd_helpers import statsd
 from miniray.lib.helpers import Limits, desc, GB_TO_BYTES, MAX_WORKER_LOOP_SECONDS, TASK_TIMEOUT_GRACE_SECONDS, JOB_CACHE_SIZE
-from miniray.lib.uv import sync_venv_cache, cleanup_venvs, populate_venv_cache_from_disk, pycache_dir_for_venv
+from miniray.lib.uv import sync_venv_cache, cleanup_venvs, populate_venv_cache_from_disk, pycache_base_dir, pycache_dir_for_venv
 from miniray.executor import MinirayResultHeader, JobMetadata, TaskRecord, TaskState, get_metadata_key, get_tasks_key
 
 
@@ -60,7 +60,7 @@ TMP_DIR_ROOT = Path("/dev/shm/tmp") / CGROUP_NODE
 # you need a really good reason to use a global directory shared across all tasks
 # (normally you should use the tmp directory that is cleaned up after every task)
 CUPY_CACHE_DIR = TMP_DIR_ROOT / "cupy"
-PYCACHE_DIR = Path(os.getenv('MINIRAY_PYCACHE_DIR', f"/var/cache/miniray/pycache_{TASK_UID}"))
+PYCACHE_DIR = pycache_base_dir(TASK_UID)
 TRITON_SERVER_ENABLED = int(os.getenv('TRITON_SERVER_ENABLED', '0'))
 
 

--- a/worker.py
+++ b/worker.py
@@ -37,7 +37,7 @@ from miniray.lib.triton_helpers import TRITON_SERVER_ADDRESS, check_triton_serve
 from miniray.lib.system_helpers import get_cgroup_cpu_usage, get_cgroup_mem_usage, get_gpu_stats, get_gpu_mem_usage, get_gpu_utilization
 from miniray.lib.statsd_helpers import statsd
 from miniray.lib.helpers import Limits, desc, GB_TO_BYTES, MAX_WORKER_LOOP_SECONDS, TASK_TIMEOUT_GRACE_SECONDS, JOB_CACHE_SIZE
-from miniray.lib.uv import sync_venv_cache, cleanup_venvs, populate_venv_cache_from_disk
+from miniray.lib.uv import sync_venv_cache, cleanup_venvs, populate_venv_cache_from_disk, pycache_dir_for_venv
 from miniray.executor import MinirayResultHeader, JobMetadata, TaskRecord, TaskState, get_metadata_key, get_tasks_key
 
 
@@ -60,7 +60,7 @@ TMP_DIR_ROOT = Path("/dev/shm/tmp") / CGROUP_NODE
 # you need a really good reason to use a global directory shared across all tasks
 # (normally you should use the tmp directory that is cleaned up after every task)
 CUPY_CACHE_DIR = TMP_DIR_ROOT / "cupy"
-PYCACHE_DIR = TMP_DIR_ROOT / "pycache"
+PYCACHE_DIR = Path(os.getenv('MINIRAY_PYCACHE_DIR', f"/var/cache/miniray/pycache_{TASK_UID}"))
 TRITON_SERVER_ENABLED = int(os.getenv('TRITON_SERVER_ENABLED', '0'))
 
 
@@ -76,7 +76,8 @@ def setup_global_dirs():
   os.chown(CUPY_CACHE_DIR, TASK_UID, TASK_UID)
   CUPY_CACHE_DIR.chmod(0o755)
 
-  PYCACHE_DIR.mkdir(parents=True)
+  # keep python bytecode cache on local disk instead of inside the venvs on NFS.
+  PYCACHE_DIR.mkdir(parents=True, exist_ok=True)
   os.chown(PYCACHE_DIR, TASK_UID, TASK_UID)
   PYCACHE_DIR.chmod(0o755)
 
@@ -225,7 +226,7 @@ class Task:
         **os.environ,
         'NO_PROGRESS': '1',
         'CUPY_CACHE_DIR': str(CUPY_CACHE_DIR),
-        'PYTHONPYCACHEPREFIX': str(PYCACHE_DIR),
+        'PYTHONPYCACHEPREFIX': str(pycache_dir_for_venv(self.job, TASK_UID)),
         'CUDA_VISIBLE_DEVICES': ','.join(cuda_visible_devices),
         'USER': 'batman',
         'HOME': '/home/batman',

--- a/worker.py
+++ b/worker.py
@@ -37,7 +37,7 @@ from miniray.lib.triton_helpers import TRITON_SERVER_ADDRESS, check_triton_serve
 from miniray.lib.system_helpers import get_cgroup_cpu_usage, get_cgroup_mem_usage, get_gpu_stats, get_gpu_mem_usage, get_gpu_utilization
 from miniray.lib.statsd_helpers import statsd
 from miniray.lib.helpers import Limits, desc, GB_TO_BYTES, MAX_WORKER_LOOP_SECONDS, TASK_TIMEOUT_GRACE_SECONDS, JOB_CACHE_SIZE
-from miniray.lib.uv import sync_venv_cache, cleanup_venvs, populate_venv_cache_from_disk, pycache_base_dir, pycache_dir_for_venv
+from miniray.lib.uv import sync_venv_cache, cleanup_venvs, populate_venv_cache_from_disk, pycache_dir_for_venv
 from miniray.executor import MinirayResultHeader, JobMetadata, TaskRecord, TaskState, get_metadata_key, get_tasks_key
 
 
@@ -60,7 +60,7 @@ TMP_DIR_ROOT = Path("/dev/shm/tmp") / CGROUP_NODE
 # you need a really good reason to use a global directory shared across all tasks
 # (normally you should use the tmp directory that is cleaned up after every task)
 CUPY_CACHE_DIR = TMP_DIR_ROOT / "cupy"
-PYCACHE_DIR = pycache_base_dir(TASK_UID)
+PYCACHE_DIR = Path(f"/var/cache/miniray/pycache_{TASK_UID}")
 TRITON_SERVER_ENABLED = int(os.getenv('TRITON_SERVER_ENABLED', '0'))
 
 

--- a/worker.py
+++ b/worker.py
@@ -250,7 +250,7 @@ class Task:
       if DEBUG: print("[worker]", " ".join(p_args))
 
       t0 = time.perf_counter()
-      self.proc = subprocess.Popen(p_args, user=0, group=self.task_gid, extra_groups=task_extra_groups, cwd=str(EMPTY_DIR), env=p_env,
+      self.proc = subprocess.Popen(p_args, user=TASK_UID, group=self.task_gid, extra_groups=task_extra_groups, cwd=str(EMPTY_DIR), env=p_env,
                                    start_new_session=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
       cgroup_add_pid(self.cgroup_name, self.proc.pid)
       assert self.proc.stdin is not None

--- a/worker.py
+++ b/worker.py
@@ -60,6 +60,7 @@ TMP_DIR_ROOT = Path("/dev/shm/tmp") / CGROUP_NODE
 # you need a really good reason to use a global directory shared across all tasks
 # (normally you should use the tmp directory that is cleaned up after every task)
 CUPY_CACHE_DIR = TMP_DIR_ROOT / "cupy"
+PYCACHE_DIR = TMP_DIR_ROOT / "pycache"
 TRITON_SERVER_ENABLED = int(os.getenv('TRITON_SERVER_ENABLED', '0'))
 
 
@@ -74,6 +75,10 @@ def setup_global_dirs():
   CUPY_CACHE_DIR.mkdir(parents=True)
   os.chown(CUPY_CACHE_DIR, TASK_UID, TASK_UID)
   CUPY_CACHE_DIR.chmod(0o755)
+
+  PYCACHE_DIR.mkdir(parents=True)
+  os.chown(PYCACHE_DIR, TASK_UID, TASK_UID)
+  PYCACHE_DIR.chmod(0o755)
 
 def create_tmp_dir(path: Path, uid, gid):
   if path.exists():
@@ -220,6 +225,7 @@ class Task:
         **os.environ,
         'NO_PROGRESS': '1',
         'CUPY_CACHE_DIR': str(CUPY_CACHE_DIR),
+        'PYTHONPYCACHEPREFIX': str(PYCACHE_DIR),
         'CUDA_VISIBLE_DEVICES': ','.join(cuda_visible_devices),
         'USER': 'batman',
         'HOME': '/home/batman',


### PR DESCRIPTION
Cache task bytecode (.pyc) on local disk via PYTHONPYCACHEPREFIX

PYTHONPYCACHEPREFIX redirects all bytecode reads/writes to a per-node dir on /dev/shm, so imports never write to the codedir which can cause issues on nfs when using an older linux kernel (https://github.com/torvalds/linux/commit/99bc9f2eb3f79a2b4296d9bf43153e1d10ca50d3). PYTHONDONTWRITEBYTECODE is slower in comparison since recompiling happens per task.