### PR TITLE
closed path that can incorrectly mark processes as terminated

### DIFF
--- a/tests/test_miniray.py
+++ b/tests/test_miniray.py
@@ -164,7 +164,7 @@ def test_memory_limit():
     future_over = executor.submit(allocate_and_hash, over_limit_bytes)
     with pytest.raises(miniray.MinirayError) as excinfo:
       future_over.result()
-    assert excinfo.value.exception_type == "ChildProcessError<9>"
+    assert excinfo.value.exception_type == "ChildProcessError<-9>"
 
 
 def test_early_shutdown():

--- a/worker.py
+++ b/worker.py
@@ -274,10 +274,9 @@ class Task:
 
     # Wait for the process to terminate
     if self.proc.returncode is None:
-      pid, returncode = os.waitpid(self.proc.pid, os.WNOHANG)
-      if not pid and not self._timed_out:
+      self.proc.poll()
+      if self.proc.returncode is None and not self._timed_out:
         return False  # still waiting
-      self.proc.returncode = returncode
 
     cgroup_kill(self.cgroup_name)
     try:
@@ -288,6 +287,11 @@ class Task:
         print(stderr.decode())
     except subprocess.TimeoutExpired:
       print('Task proc communicate timed out, might be a zombie?')
+      try:
+        self.proc.kill()
+        self.proc.communicate(timeout=5)
+      except Exception as e:
+        print(f'[worker] failed to reap zombie task proc: {desc(e)}')
 
     # Read result file
     try:

--- a/worker.py
+++ b/worker.py
@@ -287,11 +287,6 @@ class Task:
         print(stderr.decode())
     except subprocess.TimeoutExpired:
       print('Task proc communicate timed out, might be a zombie?')
-      try:
-        self.proc.kill()
-        self.proc.communicate(timeout=5)
-      except Exception as e:
-        print(f'[worker] failed to reap zombie task proc: {desc(e)}')
 
     # Read result file
     try:


### PR DESCRIPTION
https://docs.python.org/3/library/os.html#os.waitpid

"options is an OR combination of flags. If it contains [WNOHANG](https://docs.python.org/3/library/os.html#os.WNOHANG) and there are no matching children in the requested state, (0, 0) is returned."

pid, returncode = os.waitpid(self.proc.pid, os.WNOHANG) returns (0,0) from a task that has not terminated. On a timeout error the returncode is set to 0 for each task, leaving them as zombies. poll() is a better alternative since it returns None when the task has not terminated : https://docs.python.org/3/library/subprocess.html#subprocess.Popen.poll 