### PR TITLE
added a non blocking polling mechanism to wait for cgroup kill to complete

### DIFF
--- a/lib/cgroup.py
+++ b/lib/cgroup.py
@@ -77,10 +77,7 @@ def cgroup_kill(name: str) -> None:
 
 
 def cgroup_is_populated(name: str | Path) -> bool:
-  try:
-    events = (_get_cgroup_path(name) / "cgroup.events").read_text()
-  except FileNotFoundError:
-    return False
+  events = (_get_cgroup_path(name) / "cgroup.events").read_text()
   fields = dict(line.split() for line in events.splitlines())
   return fields["populated"] == "1"
 

--- a/lib/cgroup.py
+++ b/lib/cgroup.py
@@ -78,9 +78,11 @@ def cgroup_kill(name: str) -> None:
 
 def cgroup_is_populated(name: str | Path) -> bool:
   try:
-    return "populated 1" in (_get_cgroup_path(name) / "cgroup.events").read_text()
+    events = (_get_cgroup_path(name) / "cgroup.events").read_text()
   except FileNotFoundError:
     return False
+  fields = dict(line.split() for line in events.splitlines())
+  return fields["populated"] == "1"
 
 
 def cgroup_clear_all_children(name: str) -> None:

--- a/lib/cgroup.py
+++ b/lib/cgroup.py
@@ -77,16 +77,10 @@ def cgroup_kill(name: str) -> None:
 
 
 def cgroup_is_populated(name: str | Path) -> bool:
-  cgroup_path = _get_cgroup_path(name)
   try:
-    with (cgroup_path / "cgroup.events").open() as f:
-      for line in f:
-        key, _, value = line.partition(" ")
-        if key == "populated":
-          return value.strip() == "1"
+    return "populated 1" in (_get_cgroup_path(name) / "cgroup.events").read_text()
   except FileNotFoundError:
     return False
-  return False
 
 
 def cgroup_clear_all_children(name: str) -> None:

--- a/lib/cgroup.py
+++ b/lib/cgroup.py
@@ -76,6 +76,19 @@ def cgroup_kill(name: str) -> None:
     f.write("1")
 
 
+def cgroup_is_populated(name: str | Path) -> bool:
+  cgroup_path = _get_cgroup_path(name)
+  try:
+    with (cgroup_path / "cgroup.events").open() as f:
+      for line in f:
+        key, _, value = line.partition(" ")
+        if key == "populated":
+          return value.strip() == "1"
+  except FileNotFoundError:
+    return False
+  return False
+
+
 def cgroup_clear_all_children(name: str) -> None:
   cgroup_path = _get_cgroup_path(name)
   cgroup_kill(name)

--- a/worker.py
+++ b/worker.py
@@ -266,7 +266,6 @@ class Task:
 
     self._timed_out = time.perf_counter() > self.start_time + self.limits.timeout_seconds
 
-    # Wait for the task to finish (or time out), then kill the whole cgroup once.
     if self._kill_deadline is None:
       self.proc.poll()
       if self.proc.returncode is None and not self._timed_out:

--- a/worker.py
+++ b/worker.py
@@ -311,7 +311,7 @@ class Task:
       return True
     if cgroup_is_populated(self.cgroup_name):
       if not exiting:
-        raise RuntimeError(f"{self.cgroup_name}: a process survived SIGKILL+{SIGKILL_GRACE_SECONDS}s, restarting worker to reclaim the cgroup")
+        raise RuntimeError(f"{self.cgroup_name}: a process survived SIGKILL+{SIGKILL_GRACE_SECONDS}s")
       print(f"[worker] {self.cgroup_name}: a process survived SIGKILL+{SIGKILL_GRACE_SECONDS}s")
     else:
       cgroup_delete(self.cgroup_name, recursive=True)

--- a/worker.py
+++ b/worker.py
@@ -277,7 +277,7 @@ class Task:
     # Poll until every process in the cgroup has exited.
     if cgroup_is_populated(self.cgroup_name):
       if not exiting and time.perf_counter() < self._kill_deadline:
-        return False  # let sigkill take effect
+        return False  # still waiting on sigkill
       print(f"[worker] {self.cgroup_name} still populated after {SIGKILL_GRACE_SECONDS}s")
 
     try:

--- a/worker.py
+++ b/worker.py
@@ -29,7 +29,7 @@ from typing import BinaryIO, Optional, cast
 from tritonclient.http import InferenceServerClient
 
 from miniray.lib.cgroup import cgroup_create, cgroup_set_subcontrollers, cgroup_set_memory_limit, \
-                               cgroup_set_numa_nodes, cgroup_add_pid, cgroup_kill, cgroup_delete, cgroup_clear_all_children, CGROUP_DELETE_RETRIES
+                               cgroup_set_numa_nodes, cgroup_add_pid, cgroup_kill, cgroup_delete, cgroup_clear_all_children, cgroup_is_populated
 from miniray.lib.sig_term_handler import SigTermHandler
 from miniray.lib.resource_manager import ResourceManager, ResourceLimitError
 from miniray.lib.worker_helpers import ExponentialBackoff
@@ -47,6 +47,7 @@ DEBUG = os.getenv("DEBUG_WORKER", None)
 REDIS_HOST = os.getenv('REDIS_HOST', 'redis.comma.internal')
 PIPELINE_QUEUE = os.getenv('PIPELINE_QUEUE', 'local'+"-"+HOST_NAME)   # override this in systemd
 SLEEP_TIME_MAX = int(os.getenv('SLEEP_TIME_MAX', '2'))
+SIGKILL_GRACE_SECONDS = 60
 
 EMPTY_DIR = Path("/tmp/empty")  # Run worker_task.py from an empty directory so relative path lookups don't hit code.nfs
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -112,21 +113,13 @@ def cleanup_shm_by_gid(alloc_id, triton_client, gid):
     shutil.rmtree(tmp_dir)
 
 
-def cleanup_cgroup_with_retries(cgroup_name: str, ignore_errors: bool=False) -> None:
-  for attempt in range(CGROUP_DELETE_RETRIES + 1):
-    try:
-      cgroup_kill(cgroup_name)
-      cgroup_delete(cgroup_name, recursive=True)
-      return
-    except Exception as e:
-      print(f"[worker] {cgroup_name} cgroup cleanup failed: {desc(e)}")
-      if ignore_errors:
-        return
-      if attempt >= CGROUP_DELETE_RETRIES:
-        raise RuntimeError(
-          f"fatal cgroup cleanup failure for {cgroup_name} after {CGROUP_DELETE_RETRIES + 1} attempts"
-        ) from e
-      time.sleep(1)
+def cleanup_cgroup(cgroup_name: str, ignore_errors: bool=False) -> None:
+  try:
+    cgroup_delete(cgroup_name, recursive=True)
+  except OSError as e:
+    print(f"[worker] {cgroup_name} cgroup delete failed: {desc(e)}")
+    if not ignore_errors:
+      raise
 
 class Task:
   proc: Optional[subprocess.Popen]
@@ -157,6 +150,7 @@ class Task:
     self.alloc_id: Optional[str] = None
     self._reaped = False
     self._timed_out = False
+    self._kill_deadline: Optional[float] = None
     self._task_result = b''
     self._error = job_error
     self.init_timings = {}
@@ -272,13 +266,20 @@ class Task:
 
     self._timed_out = time.perf_counter() > self.start_time + self.limits.timeout_seconds
 
-    # Wait for the process to terminate
-    if self.proc.returncode is None:
+    # Wait for the task to finish (or time out), then kill the whole cgroup once.
+    if self._kill_deadline is None:
       self.proc.poll()
       if self.proc.returncode is None and not self._timed_out:
-        return False  # still waiting
+        return False  # still running
+      cgroup_kill(self.cgroup_name)
+      self._kill_deadline = time.perf_counter() + SIGKILL_GRACE_SECONDS
 
-    cgroup_kill(self.cgroup_name)
+    # Poll until every process in the cgroup has exited.
+    if cgroup_is_populated(self.cgroup_name):
+      if not exiting and time.perf_counter() < self._kill_deadline:
+        return False  # let sigkill take effect
+      print(f"[worker] {self.cgroup_name} still populated after {SIGKILL_GRACE_SECONDS}s")
+
     try:
       stdout, stderr = self.proc.communicate(timeout=1)
       if stdout:
@@ -320,7 +321,7 @@ class Task:
 
     if self.alloc_id is None:
       return True
-    cleanup_cgroup_with_retries(self.cgroup_name, exiting)
+    cleanup_cgroup(self.cgroup_name, exiting)
     return True
 
   def finish(self, exiting=False):

--- a/worker.py
+++ b/worker.py
@@ -264,11 +264,9 @@ class Task:
       cgroup_kill(self.cgroup_name)
       self._kill_deadline = time.perf_counter() + SIGKILL_GRACE_SECONDS
 
-    # Poll until every process in the cgroup has exited.
-    if cgroup_is_populated(self.cgroup_name):
-      if not exiting and time.perf_counter() < self._kill_deadline:
-        return False  # still waiting on sigkill
-      print(f"[worker] {self.cgroup_name} still populated after {SIGKILL_GRACE_SECONDS}s")
+    # Wait (non-blocking) for the cgroup to drain, up to the SIGKILL grace.
+    if cgroup_is_populated(self.cgroup_name) and not exiting and time.perf_counter() < self._kill_deadline:
+      return False  # still waiting on sigkill
 
     try:
       stdout, stderr = self.proc.communicate(timeout=1)
@@ -313,7 +311,8 @@ class Task:
       return True
     if cgroup_is_populated(self.cgroup_name):
       if not exiting:
-        raise RuntimeError(f"{self.cgroup_name} still populated after SIGKILL")
+        raise RuntimeError(f"{self.cgroup_name}: a process survived SIGKILL+{SIGKILL_GRACE_SECONDS}s, restarting worker to reclaim the cgroup")
+      print(f"[worker] {self.cgroup_name}: a process survived SIGKILL+{SIGKILL_GRACE_SECONDS}s")
     else:
       cgroup_delete(self.cgroup_name, recursive=True)
     return True

--- a/worker.py
+++ b/worker.py
@@ -112,15 +112,6 @@ def cleanup_shm_by_gid(alloc_id, triton_client, gid):
   if tmp_dir.exists():
     shutil.rmtree(tmp_dir)
 
-
-def cleanup_cgroup(cgroup_name: str, ignore_errors: bool=False) -> None:
-  try:
-    cgroup_delete(cgroup_name, recursive=True)
-  except OSError as e:
-    print(f"[worker] {cgroup_name} cgroup delete failed: {desc(e)}")
-    if not ignore_errors:
-      raise
-
 class Task:
   proc: Optional[subprocess.Popen]
   alloc_id: Optional[str]
@@ -320,7 +311,11 @@ class Task:
 
     if self.alloc_id is None:
       return True
-    cleanup_cgroup(self.cgroup_name, exiting)
+    if cgroup_is_populated(self.cgroup_name):
+      if not exiting:
+        raise RuntimeError(f"{self.cgroup_name} still populated after SIGKILL")
+    else:
+      cgroup_delete(self.cgroup_name, recursive=True)
     return True
 
   def finish(self, exiting=False):


### PR DESCRIPTION
Killing a cgroup multiple times is not useful, and when the cgroup is not dying fast enough the worker gets stuck trying over and over again (with 1 second waits).  Instead the change kills a cgroup once, then keeps checking (non blocking) if the cgroup is populated for the next 60 seconds. Once it finds that the cgroup is empty it cleans it up.