### PR TITLE
[codex] add landlock task write sandbox

### DIFF
--- a/lib/landlock.py
+++ b/lib/landlock.py
@@ -1,0 +1,129 @@
+"""Minimal ctypes wrapper for the Landlock LSM (Linux >= 5.13).
+
+Used to sandbox task processes: filesystem writes are denied everywhere except an explicit
+whitelist, while reads and execution stay unrestricted. The sandbox is inherited by all child
+processes and cannot be lifted once applied.
+
+No dependencies outside the standard library, so it can be imported from any job venv.
+"""
+from __future__ import annotations
+
+import ctypes
+import os
+import stat
+from collections.abc import Iterable
+
+# constants from linux/landlock.h
+LANDLOCK_CREATE_RULESET_VERSION = 1 << 0
+LANDLOCK_RULE_PATH_BENEATH = 1
+
+ACCESS_FS_EXECUTE = 1 << 0
+ACCESS_FS_WRITE_FILE = 1 << 1
+ACCESS_FS_READ_FILE = 1 << 2
+ACCESS_FS_READ_DIR = 1 << 3
+ACCESS_FS_REMOVE_DIR = 1 << 4
+ACCESS_FS_REMOVE_FILE = 1 << 5
+ACCESS_FS_MAKE_CHAR = 1 << 6
+ACCESS_FS_MAKE_DIR = 1 << 7
+ACCESS_FS_MAKE_REG = 1 << 8
+ACCESS_FS_MAKE_SOCK = 1 << 9
+ACCESS_FS_MAKE_FIFO = 1 << 10
+ACCESS_FS_MAKE_BLOCK = 1 << 11
+ACCESS_FS_MAKE_SYM = 1 << 12
+ACCESS_FS_REFER = 1 << 13     # ABI >= 2 (kernel 5.19)
+ACCESS_FS_TRUNCATE = 1 << 14  # ABI >= 3 (kernel 6.2)
+
+# every write-side access right; read/execute rights are left unhandled so they stay allowed everywhere
+WRITE_ACCESS = (ACCESS_FS_WRITE_FILE | ACCESS_FS_REMOVE_DIR | ACCESS_FS_REMOVE_FILE |
+                ACCESS_FS_MAKE_CHAR | ACCESS_FS_MAKE_DIR | ACCESS_FS_MAKE_REG | ACCESS_FS_MAKE_SOCK |
+                ACCESS_FS_MAKE_FIFO | ACCESS_FS_MAKE_BLOCK | ACCESS_FS_MAKE_SYM |
+                ACCESS_FS_REFER | ACCESS_FS_TRUNCATE)
+# rights that apply to regular files (the rest are directory-only and rejected by the kernel on file rules)
+FILE_ACCESS = ACCESS_FS_WRITE_FILE | ACCESS_FS_TRUNCATE
+
+SYS_LANDLOCK_CREATE_RULESET = 444
+SYS_LANDLOCK_ADD_RULE = 445
+SYS_LANDLOCK_RESTRICT_SELF = 446
+PR_SET_NO_NEW_PRIVS = 38
+
+
+class LandlockRulesetAttr(ctypes.Structure):
+  _fields_ = (("handled_access_fs", ctypes.c_uint64),)
+
+
+class LandlockPathBeneathAttr(ctypes.Structure):
+  _pack_ = 1  # packed in the uapi header
+  _fields_ = (("allowed_access", ctypes.c_uint64), ("parent_fd", ctypes.c_int32))
+
+
+_libc = ctypes.CDLL(None, use_errno=True)
+_libc.syscall.restype = ctypes.c_long
+
+
+def _syscall(nr: int, *args) -> int:
+  res = _libc.syscall(ctypes.c_long(nr), *args)
+  if res < 0:
+    err = ctypes.get_errno()
+    raise OSError(err, os.strerror(err))
+  return res
+
+
+def landlock_abi_version() -> int:
+  """Highest Landlock ABI version supported, or 0 if the kernel does not support Landlock."""
+  try:
+    return _syscall(SYS_LANDLOCK_CREATE_RULESET, None, ctypes.c_size_t(0), ctypes.c_uint32(LANDLOCK_CREATE_RULESET_VERSION))
+  except OSError:
+    return 0
+
+
+def _add_rule(ruleset_fd: int, path: str, allowed_access: int):
+  fd = os.open(path, os.O_PATH | os.O_CLOEXEC)
+  try:
+    if not stat.S_ISDIR(os.fstat(fd).st_mode):
+      allowed_access &= FILE_ACCESS
+    attr = LandlockPathBeneathAttr(allowed_access=allowed_access, parent_fd=fd)
+    _syscall(SYS_LANDLOCK_ADD_RULE, ctypes.c_int(ruleset_fd), ctypes.c_uint32(LANDLOCK_RULE_PATH_BENEATH), ctypes.byref(attr), ctypes.c_uint32(0))
+  finally:
+    os.close(fd)
+
+
+def restrict_file_writes(read_write_paths: Iterable[str], write_file_paths: Iterable[str] = ()) -> bool:
+  """Deny filesystem writes for this process (and all future children) outside the given paths.
+
+  read_write_paths: full write access (create/modify/delete) beneath these paths.
+  write_file_paths: existing files beneath these paths may only be opened for writing,
+                    nothing can be created or removed (e.g. "/dev" for device nodes).
+
+  Reads and execution stay unrestricted. Whitelist paths that don't exist are skipped.
+  Also blocks filesystem topology changes (mount/umount) and, via NO_NEW_PRIVS, setuid binaries.
+  Returns False if the kernel does not support Landlock, True once the sandbox is applied.
+  """
+  abi = landlock_abi_version()
+  if abi < 1:
+    return False
+
+  handled = WRITE_ACCESS
+  if abi < 2:
+    handled &= ~ACCESS_FS_REFER
+  if abi < 3:
+    handled &= ~ACCESS_FS_TRUNCATE
+
+  ruleset_attr = LandlockRulesetAttr(handled_access_fs=handled)
+  ruleset_fd = _syscall(SYS_LANDLOCK_CREATE_RULESET, ctypes.byref(ruleset_attr), ctypes.c_size_t(ctypes.sizeof(ruleset_attr)), ctypes.c_uint32(0))
+  try:
+    for paths, access in ((read_write_paths, handled), (write_file_paths, ACCESS_FS_WRITE_FILE)):
+      for path in paths:
+        try:
+          _add_rule(ruleset_fd, path, access)
+        except FileNotFoundError:
+          pass
+
+    # landlock_restrict_self requires no_new_privs; this also applies to the calling thread only,
+    # so the sandbox must be installed before any threads are spawned
+    if _libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
+      err = ctypes.get_errno()
+      raise OSError(err, os.strerror(err))
+    _syscall(SYS_LANDLOCK_RESTRICT_SELF, ctypes.c_int(ruleset_fd), ctypes.c_uint32(0))
+  finally:
+    os.close(ruleset_fd)
+  return True

--- a/lib/task_sandbox.py
+++ b/lib/task_sandbox.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+SANDBOX_ENV = "MINIRAY_SANDBOX"
+WRITE_PATHS_ENV = "MINIRAY_SANDBOX_WRITE_PATHS"
+
+LANDLOCK_BACKEND = "landlock"
+
+
+def sandbox_backends(env: Mapping[str, str] = os.environ) -> frozenset[str]:
+  spec = env.get(SANDBOX_ENV, LANDLOCK_BACKEND).strip().lower()
+  if spec in {"", "1", "true", "yes", "on"}:
+    return frozenset({LANDLOCK_BACKEND})
+  if spec in {"0", "false", "no", "off", "none", "disabled"}:
+    return frozenset()
+
+  backends = frozenset(part.strip() for part in spec.replace("+", ",").split(",") if part.strip())
+  invalid = backends - {LANDLOCK_BACKEND}
+  if invalid:
+    raise ValueError(f"unsupported {SANDBOX_ENV} backend(s): {', '.join(sorted(invalid))}")
+  return backends
+
+
+def sandbox_uses_landlock(env: Mapping[str, str] = os.environ) -> bool:
+  return LANDLOCK_BACKEND in sandbox_backends(env)
+
+
+def sandbox_write_paths(env: Mapping[str, str] = os.environ, *, create_pycache: bool = False, existing_only: bool = False) -> list[str]:
+  pycache_dir = Path(env["PYTHONPYCACHEPREFIX"])
+  if create_pycache:
+    pycache_dir.mkdir(parents=True, exist_ok=True)
+
+  paths = [
+    env["TMPDIR"],
+    env["CUPY_CACHE_DIR"],
+    str(pycache_dir),
+    "/dev/shm",
+    *filter(None, env.get(WRITE_PATHS_ENV, "").split(":")),
+  ]
+
+  deduped = []
+  seen = set()
+  for path in paths:
+    normalized = str(Path(path))
+    if normalized in seen or (existing_only and not Path(normalized).exists()):
+      continue
+    seen.add(normalized)
+    deduped.append(normalized)
+  return deduped

--- a/lib/worker_task.py
+++ b/lib/worker_task.py
@@ -8,8 +8,25 @@ import cloudpickle
 import wrapt
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # sibling imports must work from any job venv
+from landlock import restrict_file_writes
+from task_sandbox import sandbox_uses_landlock, sandbox_write_paths
+
 # Tasks initially start as root so they can be moved into the appropriate cgroup
 os.setuid(int(os.getenv("TASK_UID", 1000)))
+
+
+def apply_sandbox():
+  # Deny filesystem writes outside the task's scratch directories; reads and execution stay
+  # unrestricted. The sandbox is inherited by everything the task spawns and cannot be lifted.
+  # Jobs can whitelist extra paths via MINIRAY_SANDBOX_WRITE_PATHS (colon-separated).
+  read_write_paths = sandbox_write_paths(create_pycache=True)
+  if not restrict_file_writes(read_write_paths, write_file_paths=["/dev"]):  # /dev: GPU nodes, /dev/null, ...
+    print("[worker_task] Landlock unsupported by kernel, task runs without write sandbox", file=sys.stderr)
+
+
+if sandbox_uses_landlock():
+  apply_sandbox()
 
 @wrapt.when_imported("cv2")
 def cv2_import_hook(cv2):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,6 @@ exclude = ["miniray"]
 
 [tool.ty.src]
 exclude = ["miniray"]
+
+[tool.ty.environment]
+extra-paths = ["lib"]  # worker_task.py imports its siblings directly (it runs standalone inside job venvs)

--- a/tests/test_miniray.py
+++ b/tests/test_miniray.py
@@ -6,6 +6,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import miniray
+from miniray.lib.task_sandbox import sandbox_backends
 from .dstate_helpers import (
   block_in_frozen_filesystem,
   wait_for_worker_to_disappear,
@@ -15,7 +16,6 @@ MINIRAY_PRIORITY = 1000
 MINIRAY_MEMORY_GB = 0.4
 DSTATE_TASK_COUNT = 4
 QUEUE_NAME = os.environ.get('MINIRAY_QUEUE', miniray.REMOTE_QUEUE)
-
 
 class MinirayTestClass:
   def __init__(self, value):
@@ -129,6 +129,10 @@ def test_timeout():
     assert excinfo.value.exception_type == "TimeoutError"
 
 
+# the dstate tasks mount/freeze filesystems and write outside the sandbox whitelist by design
+DSTATE_ENV = {'MINIRAY_SANDBOX': '0'}
+
+
 @pytest.mark.dstate
 def test_d_state_tasks_do_not_crash_worker():
   hold_seconds = 30
@@ -137,6 +141,7 @@ def test_d_state_tasks_do_not_crash_worker():
   with miniray.Executor(job_name="miniray_test_dstate_no_crash",
                         priority=MINIRAY_PRIORITY,
                         queue_name=QUEUE_NAME,
+                        env=DSTATE_ENV,
                         limits={"memory": MINIRAY_MEMORY_GB, "timeout_seconds": timeout_seconds}) as executor:
     futures = [executor.submit(block_in_frozen_filesystem, hold_seconds) for _ in range(DSTATE_TASK_COUNT)]
     t0 = time.monotonic()
@@ -161,6 +166,7 @@ def test_d_state_task_crashes_worker():
   with miniray.Executor(job_name="miniray_test_dstate_crash",
                         priority=MINIRAY_PRIORITY,
                         queue_name=QUEUE_NAME,
+                        env=DSTATE_ENV,
                         limits={"memory": MINIRAY_MEMORY_GB, "timeout_seconds": timeout_seconds}) as executor:
     future = executor.submit(block_in_frozen_filesystem, hold_seconds)
     with pytest.raises(miniray.MinirayError) as excinfo:
@@ -169,6 +175,57 @@ def test_d_state_task_crashes_worker():
   assert excinfo.value.exception_type == "RuntimeError"
   assert "task lost" in excinfo.value.exception_desc
   wait_for_worker_to_disappear(QUEUE_NAME, excinfo.value.worker)
+
+
+def test_sandbox_backend_parsing():
+  assert sandbox_backends({}) == frozenset({'landlock'})
+  assert sandbox_backends({'MINIRAY_SANDBOX': '0'}) == frozenset()
+  with pytest.raises(ValueError):
+    sandbox_backends({'MINIRAY_SANDBOX': 'bwrap'})
+
+
+def test_sandbox_blocks_writes_outside_whitelist():
+  def probe():
+    import tempfile
+    denied = []
+    for target in [Path('/var/tmp/miniray_sandbox_probe'), Path('/usr/local/miniray_sandbox_probe')]:
+      try:
+        target.write_bytes(b'x')
+        target.unlink()
+      except PermissionError:
+        denied.append(str(target))
+
+    # whitelisted locations must still be writable
+    with tempfile.NamedTemporaryFile() as f:  # honors TMPDIR
+      f.write(b'x')
+    scratch = Path(os.environ['TMPDIR']) / 'sandbox_probe_dir'
+    scratch.mkdir()
+    (scratch / 'probe').write_bytes(b'x')
+    Path('/dev/null').write_bytes(b'x')
+    return denied
+
+  with miniray.Executor(job_name='miniray_test_sandbox',
+                        priority=MINIRAY_PRIORITY,
+                        queue_name=QUEUE_NAME,
+                        env={'MINIRAY_SANDBOX': 'landlock'},
+                        limits={'memory': MINIRAY_MEMORY_GB}) as executor:
+    denied = executor.submit(probe).result()
+    assert denied == ['/var/tmp/miniray_sandbox_probe', '/usr/local/miniray_sandbox_probe']
+
+
+def test_sandbox_extra_write_paths():
+  def probe(path):
+    Path(path).write_bytes(b'x')
+    Path(path).unlink()
+    return "ok"
+
+  target = '/var/tmp/miniray_sandbox_whitelisted'
+  with miniray.Executor(job_name='miniray_test_sandbox_whitelist',
+                        priority=MINIRAY_PRIORITY,
+                        queue_name=QUEUE_NAME,
+                        env={'MINIRAY_SANDBOX': 'landlock', 'MINIRAY_SANDBOX_WRITE_PATHS': '/var/tmp'},
+                        limits={'memory': MINIRAY_MEMORY_GB}) as executor:
+    assert executor.submit(probe, target).result() == "ok"
 
 
 def test_class_method_submission():


### PR DESCRIPTION
## Summary

Adds a Landlock-based filesystem write sandbox for miniray task processes. By default, worker tasks now deny filesystem writes outside the task scratch/cache paths while keeping reads and execution unrestricted.

Allowed write paths are built from the task environment: `TMPDIR`, `CUPY_CACHE_DIR`, `PYTHONPYCACHEPREFIX`, `/dev/shm`, and optional `MINIRAY_SANDBOX_WRITE_PATHS` entries. Jobs can disable the sandbox with `MINIRAY_SANDBOX=0` when they intentionally need broader filesystem writes.

## Impact

This protects worker hosts from accidental task writes to global filesystem locations while preserving existing task read/execute behavior and subprocess inheritance. D-state tests explicitly opt out because they mount/freeze filesystems by design.

## Validation

- `uv run python -m py_compile lib/task_sandbox.py lib/landlock.py lib/worker_task.py tests/test_miniray.py`
- `uv run ruff check lib/worker_task.py lib/landlock.py lib/task_sandbox.py tests/test_miniray.py`
- `uv run ty check lib/worker_task.py lib/landlock.py lib/task_sandbox.py tests/test_miniray.py`
- `uv run pytest tests/test_miniray.py -q -k 'sandbox_backend_parsing'`
- `git diff --check`

Note: local `git commit` hooks passed AST/merge/symlink/large-file/ruff checks, but the hook-managed `ty` step failed to spawn `ty` from its isolated pre-commit environment. The project-level `uv run ty check ...` command above passed.