### PR TITLE
Retry transient redis errors on all clients

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -28,7 +28,7 @@ from tqdm import tqdm
 from types import TracebackType
 from typing import Any, Callable, Iterable, Iterator, NamedTuple, Optional, Sequence, cast
 
-from miniray.lib.helpers import Limits, extract_error, get_stream_logger
+from miniray.lib.helpers import Limits, extract_error, get_stream_logger, get_redis_client
 
 MAX_ARG_STRLEN = 131071  # max length for unix string arguments, see https://stackoverflow.com/a/29802900
 REDIS_HOST = os.getenv('REDIS_HOST', 'redis.comma.internal')
@@ -151,7 +151,7 @@ def _execute_batch(fn, *batch, **kwargs):
 
 def _wrap_result_local_redis(data: Any, timeout_seconds: int) -> tuple[str, str]:
   redis_result_host = REDIS_HOST if USE_MAIN_RESULT_REDIS else socket.gethostname()
-  r = StrictRedis(host=redis_result_host, db=10)
+  r = get_redis_client(redis_result_host, db=10)
   run_id = cast(dict[str, Any], r.info('server'))['run_id']
   key = f"miniray-{uuid.uuid4()}@{run_id}"
   pipe = r.pipeline()
@@ -167,7 +167,7 @@ def _local_worker_init():
 
 @cache
 def _get_redis_client(hostname: str) -> StrictRedis:
-  return StrictRedis(host=hostname, db=10)
+  return get_redis_client(hostname, db=10)
 
 class LocalExecutor(ProcessPoolExecutor):
   def __init__(self, env: dict[str, str]):
@@ -235,9 +235,9 @@ class Executor(BaseExecutor):
     self.result_queue_id = f'fq-{self.submit_queue_id}'
 
     self._futures: dict[str, tuple[list[Future], bool, bytes]] = {}
-    self._submit_redis_master = StrictRedis(host=self.config.redis_host, port=6379, db=1, socket_keepalive=True)
-    self._result_redis = StrictRedis(host=self.config.redis_host, port=6379, db=5, socket_keepalive=True)
-    self._claimed_redis = StrictRedis(host=self.config.redis_host, port=6379, db=2, socket_keepalive=True)
+    self._submit_redis_master = get_redis_client(self.config.redis_host, port=6379, db=1, socket_keepalive=True)
+    self._result_redis = get_redis_client(self.config.redis_host, port=6379, db=5, socket_keepalive=True)
+    self._claimed_redis = get_redis_client(self.config.redis_host, port=6379, db=2, socket_keepalive=True)
     self._shutdown_lock = threading.Lock()
     self._shutdown_writer_threads = False
     self._shutdown_reader_thread: Optional[ShutdownMode] = None

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -3,6 +3,10 @@ import sys
 import logging
 from typing import Optional
 from dataclasses import dataclass, asdict
+from redis import StrictRedis
+from redis.retry import Retry
+from redis.backoff import ExponentialBackoff as RedisBackoff
+from redis.exceptions import ConnectionError as RedisConnectionError, TimeoutError as RedisTimeoutError
 
 # Memory conversion constants
 GB_TO_BYTES = 1024 ** 3
@@ -12,6 +16,14 @@ TASK_TIMEOUT_GRACE_SECONDS = 10
 MAX_WORKER_LOOP_SECONDS = 30
 JOB_CACHE_SIZE = 64
 JOB_BLOCK_SECONDS = 60 * 5  # 5 minutes
+
+# Retry transient redis errors (connection drops, timeouts) so a brief redis blip doesn't crash the worker/executor.
+REDIS_RETRY = Retry(RedisBackoff(cap=10, base=1), 3)
+REDIS_RETRY_ON_ERROR: list[type[Exception]] = [RedisConnectionError, RedisTimeoutError]
+
+
+def get_redis_client(host: str, port: int = 6379, db: int = 0, **kwargs) -> StrictRedis:
+  return StrictRedis(host=host, port=port, db=db, retry=REDIS_RETRY, retry_on_error=REDIS_RETRY_ON_ERROR, **kwargs)
 
 @dataclass
 class Limits:

--- a/worker.py
+++ b/worker.py
@@ -36,7 +36,7 @@ from miniray.lib.worker_helpers import ExponentialBackoff
 from miniray.lib.triton_helpers import TRITON_SERVER_ADDRESS, check_triton_server_health, wait_for_triton_server
 from miniray.lib.system_helpers import get_cgroup_cpu_usage, get_cgroup_mem_usage, get_gpu_stats, get_gpu_mem_usage, get_gpu_utilization
 from miniray.lib.statsd_helpers import statsd
-from miniray.lib.helpers import Limits, desc, GB_TO_BYTES, MAX_WORKER_LOOP_SECONDS, TASK_TIMEOUT_GRACE_SECONDS, JOB_CACHE_SIZE
+from miniray.lib.helpers import Limits, desc, GB_TO_BYTES, MAX_WORKER_LOOP_SECONDS, TASK_TIMEOUT_GRACE_SECONDS, JOB_CACHE_SIZE, get_redis_client
 from miniray.lib.uv import sync_venv_cache, cleanup_venvs, populate_venv_cache_from_disk, pycache_dir_for_venv
 from miniray.executor import MinirayResultHeader, JobMetadata, TaskRecord, TaskState, get_metadata_key, get_tasks_key
 
@@ -534,9 +534,9 @@ def main():
   sigterm_handler = SigTermHandler(callback=sig_callback)
   backoff = ExponentialBackoff(SLEEP_TIME_MAX, DEBUG)
 
-  r_master = StrictRedis(host=REDIS_HOST, port=6379, db=1)
-  r_results = StrictRedis(host=REDIS_HOST, port=6379, db=5)
-  r_claimed = StrictRedis(host=REDIS_HOST, port=6379, db=2)
+  r_master = get_redis_client(REDIS_HOST, port=6379, db=1)
+  r_results = get_redis_client(REDIS_HOST, port=6379, db=5)
+  r_claimed = get_redis_client(REDIS_HOST, port=6379, db=2)
 
   os.nice(1)
 


### PR DESCRIPTION
## Summary

Adds client-level retry to all redis clients so a brief redis blip (restart, momentary network loss) doesn't crash the worker or executor.

## Problem

Previously, every redis call would raise immediately on a connection error or timeout. In the worker this crashes the process (caught by the main `try/except` → `fatal_error` → exit). In the executor's `_writer_loop` it does `sys.exit(1)`, killing the whole process and all in-flight futures.

## Fix

redis-py 7.3.0 supports client-level retry — configure it once per client and every call retries automatically, no per-call wrapping. Added a shared `get_redis_client` helper in `lib/helpers.py`:

```python
REDIS_RETRY = Retry(ExponentialBackoff(cap=10, base=1), 3)
REDIS_RETRY_ON_ERROR = [ConnectionError, TimeoutError]

def get_redis_client(host, port=6379, db=0, **kwargs) -> StrictRedis:
  return StrictRedis(host=host, port=port, db=db, retry=REDIS_RETRY, retry_on_error=REDIS_RETRY_ON_ERROR, **kwargs)
```

Applied to all 7 `StrictRedis()` constructions:
- `executor.py`: 3 in `Executor.__init__` (submit/result/claimed), 1 in `_wrap_result_local_redis`, 1 in `_get_redis_client`
- `worker.py`: 3 in `main` (r_master/r_results/r_claimed)

## What it covers

Transient blips — up to ~14s of retries with exponential backoff (verified: 3 retries against a dead port took 14s before raising). Handles redis restarts and brief network loss without crashing.

## What it doesn't cover

Longer outages still raise after retries exhaust. The worker then crashes (by design — relies on systemd/docker restart). The executor's `_writer_loop` still does `sys.exit(1)` on a long outage; fixing that to a retry loop is a separate change.

`ruff check .` and `ty check .` pass.