### PR TITLE
enforce 120 char line length limit

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -43,8 +43,10 @@ MAX_PRIORITY = 20
 DEFAULT_LOGGER = get_stream_logger('miniray', level=logging.INFO)
 
 MISSING_RESULT_PAYLOAD_ERROR = (
-  f"Did not find payload on worker redis. Results may be piling up and reader has fallen more than {DEFAULT_RESULT_PAYLOAD_TIMEOUT_SECONDS/60:.1f}"
-  " minutes behind. If your results are small, consider a larger chunksize. If your results are big, consider multiple miniray executors.")
+  f"Did not find payload on worker redis. Results may be piling up and reader has fallen more than "
+  f"{DEFAULT_RESULT_PAYLOAD_TIMEOUT_SECONDS/60:.1f}"
+  " minutes behind. If your results are small, consider a larger chunksize."
+  " If your results are big, consider multiple miniray executors.")
 
 #TODO xx and code.nfs should not be referenced here
 XX_BASEPATH = Path(__file__).resolve().parent.parent
@@ -137,7 +139,10 @@ def sync_local_codedir(job_desc: str) -> str:
   if (local_exclude := XX_BASEPATH / "training/.training_cache_exclude.local").exists():
     excludes.append(f"--exclude-from={local_exclude}")
   dest = cache_dir.relative_to(Path("/code.nfs")).as_posix()
-  subprocess.check_call(["rsync", "-a", "--max-delete=0", "--copy-dest=/xx", "--info=progress2", *excludes, f"{XX_BASEPATH}/", f"rsync://app01:1026/code_nfs/{dest}/"])
+  subprocess.check_call([
+    "rsync", "-a", "--max-delete=0", "--copy-dest=/xx", "--info=progress2", *excludes,
+    f"{XX_BASEPATH}/", f"rsync://app01:1026/code_nfs/{dest}/",
+  ])
   return str(cache_dir)
 
 def _execute_batch(fn, *batch, **kwargs):
@@ -216,7 +221,8 @@ class Executor(BaseExecutor):
       limits = replace(config.limits, **limits)
     config = replace(config, limits=limits)
 
-    assert config.job_name.replace('.','').replace('-', '').replace('_', '').isalnum(), f'Invalid job name: {config.job_name}'
+    assert config.job_name.replace('.','').replace('-', '').replace('_', '').isalnum(), \
+      f'Invalid job name: {config.job_name}'
     job_desc = f"{config.job_name}_{str(uuid.uuid4())[:8]}"
 
     if config.codedir is not None:
@@ -266,7 +272,9 @@ class Executor(BaseExecutor):
     self._reader_thread.start()
     return super().__enter__()
 
-  def __exit__(self, exc_type: Optional[type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]):
+  def __exit__(
+    self, exc_type: Optional[type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType],
+  ):
     try:
       self.shutdown()
     except (Exception, KeyboardInterrupt):
@@ -290,7 +298,8 @@ class Executor(BaseExecutor):
           for future in futures:
             future.cancel()
 
-      self._submit_redis_master.delete(get_tasks_key(self.submit_queue_id), self.submit_queue_id, get_metadata_key(self.submit_queue_id))
+      self._submit_redis_master.delete(
+        get_tasks_key(self.submit_queue_id), self.submit_queue_id, get_metadata_key(self.submit_queue_id))
 
   def submit(self, fn: Callable, /, *args, **kwargs) -> Future:
     assert not self._shutdown_reader_thread, "Cannot submit new tasks after shutdown has started"
@@ -302,7 +311,9 @@ class Executor(BaseExecutor):
     self._futures[task_uuid] = ([future], True, task[1])
     return future
 
-  def map(self, fn: Callable, *iterables: Iterable[Any], timeout: Optional[float] = None, chunksize: int = 1) -> Iterator[Any]:
+  def map(
+    self, fn: Callable, *iterables: Iterable[Any], timeout: Optional[float] = None, chunksize: int = 1,
+  ) -> Iterator[Any]:
     if timeout is not None:
       raise NotImplementedError("Timeout arg is not supported. Use `fmap` instead to get a timeout per task.")
     # submit all tasks first, then resolve the results lazily
@@ -320,7 +331,8 @@ class Executor(BaseExecutor):
     assert not self._shutdown_reader_thread, "Cannot submit new tasks after shutdown has started"
     function_ptr = self._cache_func_in_redis(fn)
     submitted_queue: Queue[Optional[Future]] = Queue()
-    writer_thread = threading.Thread(target=self._writer_loop, args=(submitted_queue, function_ptr, list(iterables), chunksize), daemon=True)
+    writer_thread = threading.Thread(
+      target=self._writer_loop, args=(submitted_queue, function_ptr, list(iterables), chunksize), daemon=True)
     writer_thread.start()
     self._writer_threads.append(writer_thread)
     while future := submitted_queue.get():
@@ -331,11 +343,13 @@ class Executor(BaseExecutor):
 
   # Worker threads
 
-  def _writer_loop(self, submitted_queue: Queue[Optional[Future]], function_ptr: str, iterables: list[Iterable[Any]], chunksize: int) -> None:
+  def _writer_loop(
+    self, submitted_queue: Queue[Optional[Future]], function_ptr: str, iterables: list[Iterable[Any]], chunksize: int,
+  ) -> None:
     try:
       args_iterator = zip(*iterables, strict=True)
       assert chunksize >= 1
-      while args := list(islice(args_iterator, chunksize * max(1, (1000 // chunksize)))):  # up to max(1000, chunksize) tasks at a time
+      while args := list(islice(args_iterator, chunksize * max(1, (1000 // chunksize)))):  # up to 1000 tasks at a time
         if self._shutdown_writer_threads:
           break
         task_args, task_futures = {}, {}
@@ -345,10 +359,13 @@ class Executor(BaseExecutor):
           task_futures[task_uuid] = [Future() for _ in batch]
           for future in task_futures[task_uuid]:
             submitted_queue.put(future)
-        tasks = dict(self._pack_task(function_ptr, b'', args, {}, task_uuid) for task_uuid, args in task_args.items())
-        self._futures.update({task_uuid: (futures, False, tasks[task_uuid]) for task_uuid, futures in task_futures.items()})  # mark as unsubmitted
+        tasks = dict(
+          self._pack_task(function_ptr, b'', args, {}, task_uuid) for task_uuid, args in task_args.items())
+        self._futures.update(
+          {task_uuid: (futures, False, tasks[task_uuid]) for task_uuid, futures in task_futures.items()})  # unsubmitted
         self._submit_tasks(list(tasks.items()))
-        self._futures.update({task_uuid: (futures, True, tasks[task_uuid]) for task_uuid, futures in task_futures.items()})  # mark as submitted
+        self._futures.update(
+          {task_uuid: (futures, True, tasks[task_uuid]) for task_uuid, futures in task_futures.items()})  # submitted
 
       submitted_queue.put(None)  # Signal the end of the stream
     except Exception:
@@ -358,7 +375,8 @@ class Executor(BaseExecutor):
 
   def _reader_loop(self) -> None:
     while True:
-      if self._shutdown_reader_thread is ShutdownMode.FORCE or (self._shutdown_reader_thread is ShutdownMode.GRACEFUL and not self._futures):
+      if self._shutdown_reader_thread is ShutdownMode.FORCE or (
+        self._shutdown_reader_thread is ShutdownMode.GRACEFUL and not self._futures):
         break
       try:
         if time.time() - self._last_lost_check > 10:
@@ -388,12 +406,17 @@ class Executor(BaseExecutor):
           self._futures.pop(task_uuid)
           claimed = cast(Optional[bytes], self._claimed_redis.get(f"claimed:{task_uuid}"))
           for future in futures:
-            future.set_exception(MinirayError("RuntimeError", f"task lost ({task_uuid})", self.submit_queue_id, claimed.decode() if claimed else ""))
+            future.set_exception(MinirayError(
+              "RuntimeError", f"task lost ({task_uuid})", self.submit_queue_id, claimed.decode() if claimed else ""))
 
-  def _pack_task(self, function_ptr: str, pickled_fn: bytes, args: Sequence[Any], kwargs: dict[str, Any], task_uuid: str) -> tuple[str, bytes]:
+  def _pack_task(
+    self, function_ptr: str, pickled_fn: bytes, args: Sequence[Any], kwargs: dict[str, Any], task_uuid: str,
+  ) -> tuple[str, bytes]:
     pickled_args = cloudpickle.dumps((args, kwargs))
     if len(pickled_fn) + len(pickled_args) > MAX_ARG_STRLEN:
-      raise RuntimeError(f"Can't send target, size ({len(pickled_fn) + len(pickled_args)}) exceeds max allowed length ({MAX_ARG_STRLEN})")
+      raise RuntimeError(
+        f"Can't send target, size ({len(pickled_fn) + len(pickled_args)}) exceeds max allowed "
+        f"length ({MAX_ARG_STRLEN})")
     record = TaskRecord(
       uuid=task_uuid,
       job=self.submit_queue_id,
@@ -440,14 +463,16 @@ class Executor(BaseExecutor):
             self._resubmit_task(futures, header, record, reason='result payload lost (worker redis recreated)')
           else:
             for future in futures:
-              future.set_exception(MinirayError("MinirayError", MISSING_RESULT_PAYLOAD_ERROR, header.job, header.worker))
+              future.set_exception(MinirayError(
+                "MinirayError", MISSING_RESULT_PAYLOAD_ERROR, header.job, header.worker))
         else:
           subtasks = cloudpickle.loads(result_payload)
           for future, subtask in zip(futures, subtasks, strict=True):
             if subtask.succeeded:
               future.set_result(subtask.result)
             else:
-              future.set_exception(MinirayError(subtask.exception_type, subtask.exception_desc, header.job, header.worker))
+              future.set_exception(MinirayError(
+                subtask.exception_type, subtask.exception_desc, header.job, header.worker))
       elif header.exception_type == "WorkerShutdown":
         self._resubmit_task(futures, header, record, 'killed by worker shutdown')
       else:
@@ -455,17 +480,21 @@ class Executor(BaseExecutor):
           future.set_exception(MinirayError(header.exception_type, header.exception_desc, header.job, header.worker))
     except RedisConnectionError:
       for future in futures:
-        future.set_exception(MinirayError("RedisConnectionError", "lost connection to redis while fetching result payload", header.job, header.worker))
+        future.set_exception(MinirayError(
+          "RedisConnectionError", "lost connection to redis while fetching result payload", header.job, header.worker))
     except Exception as e:
       for future in futures:
         future.set_exception(e)
 
   def _submit_tasks(self, tasks: list[tuple[str, bytes]]) -> None:
-    self._submit_redis_master.hsetex(get_tasks_key(self.submit_queue_id), mapping=dict(tasks), ex=self.config.queue_timeout)
+    self._submit_redis_master.hsetex(
+      get_tasks_key(self.submit_queue_id), mapping=dict(tasks), ex=self.config.queue_timeout)
     uuids = [task_uuid for task_uuid, _ in tasks]
     self._submit_redis_master.lpush(f'{self.submit_queue_id}', *uuids)
 
-def log(iterable: Iterable[Future], logger: Any = DEFAULT_LOGGER, desc: str = 'running miniray tasks', **kwargs: Any) -> list[Any]:
+def log(
+  iterable: Iterable[Future], logger: Any = DEFAULT_LOGGER, desc: str = 'running miniray tasks', **kwargs: Any,
+) -> list[Any]:
   results = []
   statuses: Counter[str] = Counter()
   statuses_hosts = defaultdict(list)

--- a/executor.py
+++ b/executor.py
@@ -272,9 +272,8 @@ class Executor(BaseExecutor):
     self._reader_thread.start()
     return super().__enter__()
 
-  def __exit__(
-    self, exc_type: Optional[type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType],
-  ):
+  def __exit__(self, exc_type: Optional[type[BaseException]],
+    exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]):
     try:
       self.shutdown()
     except (Exception, KeyboardInterrupt):
@@ -311,9 +310,8 @@ class Executor(BaseExecutor):
     self._futures[task_uuid] = ([future], True, task[1])
     return future
 
-  def map(
-    self, fn: Callable, *iterables: Iterable[Any], timeout: Optional[float] = None, chunksize: int = 1,
-  ) -> Iterator[Any]:
+  def map(self, fn: Callable, *iterables: Iterable[Any],
+    timeout: Optional[float] = None, chunksize: int = 1) -> Iterator[Any]:
     if timeout is not None:
       raise NotImplementedError("Timeout arg is not supported. Use `fmap` instead to get a timeout per task.")
     # submit all tasks first, then resolve the results lazily
@@ -343,9 +341,8 @@ class Executor(BaseExecutor):
 
   # Worker threads
 
-  def _writer_loop(
-    self, submitted_queue: Queue[Optional[Future]], function_ptr: str, iterables: list[Iterable[Any]], chunksize: int,
-  ) -> None:
+  def _writer_loop(self, submitted_queue: Queue[Optional[Future]],
+    function_ptr: str, iterables: list[Iterable[Any]], chunksize: int) -> None:
     try:
       args_iterator = zip(*iterables, strict=True)
       assert chunksize >= 1
@@ -411,9 +408,8 @@ class Executor(BaseExecutor):
           for future in futures:
             future.set_exception(MinirayError("RuntimeError", f"task lost ({task_uuid})", self.submit_queue_id, worker))
 
-  def _pack_task(
-    self, function_ptr: str, pickled_fn: bytes, args: Sequence[Any], kwargs: dict[str, Any], task_uuid: str,
-  ) -> tuple[str, bytes]:
+  def _pack_task(self, function_ptr: str, pickled_fn: bytes,
+    args: Sequence[Any], kwargs: dict[str, Any], task_uuid: str) -> tuple[str, bytes]:
     pickled_args = cloudpickle.dumps((args, kwargs))
     if len(pickled_fn) + len(pickled_args) > MAX_ARG_STRLEN:
       raise RuntimeError(
@@ -494,9 +490,8 @@ class Executor(BaseExecutor):
     uuids = [task_uuid for task_uuid, _ in tasks]
     self._submit_redis_master.lpush(f'{self.submit_queue_id}', *uuids)
 
-def log(
-  iterable: Iterable[Future], logger: Any = DEFAULT_LOGGER, desc: str = 'running miniray tasks', **kwargs: Any,
-) -> list[Any]:
+def log(iterable: Iterable[Future], logger: Any = DEFAULT_LOGGER,
+  desc: str = 'running miniray tasks', **kwargs: Any) -> list[Any]:
   results = []
   statuses: Counter[str] = Counter()
   statuses_hosts = defaultdict(list)

--- a/executor.py
+++ b/executor.py
@@ -359,8 +359,10 @@ class Executor(BaseExecutor):
           task_futures[task_uuid] = [Future() for _ in batch]
           for future in task_futures[task_uuid]:
             submitted_queue.put(future)
-        tasks = dict(
-          self._pack_task(function_ptr, b'', args, {}, task_uuid) for task_uuid, args in task_args.items())
+        tasks = {}
+        for task_uuid, args in task_args.items():
+          _, record = self._pack_task(function_ptr, b'', args, {}, task_uuid)
+          tasks[task_uuid] = record
         for task_uuid, futures in task_futures.items():
           self._futures[task_uuid] = (futures, False, tasks[task_uuid])  # unsubmitted
         self._submit_tasks(list(tasks.items()))

--- a/executor.py
+++ b/executor.py
@@ -359,13 +359,14 @@ class Executor(BaseExecutor):
           task_futures[task_uuid] = [Future() for _ in batch]
           for future in task_futures[task_uuid]:
             submitted_queue.put(future)
-        tasks = dict(
-          self._pack_task(function_ptr, b'', args, {}, task_uuid) for task_uuid, args in task_args.items())
-        self._futures.update(
-          {task_uuid: (futures, False, tasks[task_uuid]) for task_uuid, futures in task_futures.items()})  # unsubmitted
+        tasks = {}
+        for task_uuid, args in task_args.items():
+          tasks[task_uuid] = self._pack_task(function_ptr, b'', args, {}, task_uuid)
+        for task_uuid, futures in task_futures.items():
+          self._futures[task_uuid] = (futures, False, tasks[task_uuid])  # unsubmitted
         self._submit_tasks(list(tasks.items()))
-        self._futures.update(
-          {task_uuid: (futures, True, tasks[task_uuid]) for task_uuid, futures in task_futures.items()})  # submitted
+        for task_uuid, futures in task_futures.items():
+          self._futures[task_uuid] = (futures, True, tasks[task_uuid])  # submitted
 
       submitted_queue.put(None)  # Signal the end of the stream
     except Exception:
@@ -405,9 +406,9 @@ class Executor(BaseExecutor):
         if record is None and submitted:
           self._futures.pop(task_uuid)
           claimed = cast(Optional[bytes], self._claimed_redis.get(f"claimed:{task_uuid}"))
+          worker = claimed.decode() if claimed else ""
           for future in futures:
-            future.set_exception(MinirayError(
-              "RuntimeError", f"task lost ({task_uuid})", self.submit_queue_id, claimed.decode() if claimed else ""))
+            future.set_exception(MinirayError("RuntimeError", f"task lost ({task_uuid})", self.submit_queue_id, worker))
 
   def _pack_task(
     self, function_ptr: str, pickled_fn: bytes, args: Sequence[Any], kwargs: dict[str, Any], task_uuid: str,

--- a/executor.py
+++ b/executor.py
@@ -359,9 +359,8 @@ class Executor(BaseExecutor):
           task_futures[task_uuid] = [Future() for _ in batch]
           for future in task_futures[task_uuid]:
             submitted_queue.put(future)
-        tasks = {}
-        for task_uuid, args in task_args.items():
-          tasks[task_uuid] = self._pack_task(function_ptr, b'', args, {}, task_uuid)
+        tasks = dict(
+          self._pack_task(function_ptr, b'', args, {}, task_uuid) for task_uuid, args in task_args.items())
         for task_uuid, futures in task_futures.items():
           self._futures[task_uuid] = (futures, False, tasks[task_uuid])  # unsubmitted
         self._submit_tasks(list(tasks.items()))

--- a/lib/cgroup.py
+++ b/lib/cgroup.py
@@ -38,7 +38,9 @@ def cgroup_create(name: str) -> None:
   try:
     cgroup_path.mkdir(mode=0o755)
   except PermissionError as e:
-    raise PermissionError(f"could not create cgroup, manually create with:\nsudo mkdir -p {cgroup_path} && sudo chown $USER:$USER {cgroup_path}") from e
+    raise PermissionError(
+      f"could not create cgroup, manually create with:\nsudo mkdir -p {cgroup_path} "
+      f"&& sudo chown $USER:$USER {cgroup_path}") from e
 
 
 def cgroup_set_numa_nodes(name: str, numa_nodes: list[int]) -> None:

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -70,7 +70,11 @@ def extract_error(e):
     elif cls == "DependencyMissingError":
       msg = msg.split('/')[-3].strip()
     elif cls == "Exception":
-      patterns = ["Error, range out of bounds [0-9]{3}", "Error, requested range but got unexpected response [0-9]{3}", "Error [0-9]{3}"]
+      patterns = [
+        "Error, range out of bounds [0-9]{3}",
+        "Error, requested range but got unexpected response [0-9]{3}",
+        "Error [0-9]{3}",
+      ]
       for pattern in patterns:
         match = re.match(pattern, msg)
         if match:

--- a/lib/resource_manager.py
+++ b/lib/resource_manager.py
@@ -161,7 +161,9 @@ class ResourceManager():
     numa_node = min(candidate_nodes, key=lambda node: cpu_usages[node] / self.cpu_totals[node])
 
     if small_gpu_mem_bytes and (
-      not small_gpu or gpu_mem_usages[small_gpu.index] + small_gpu_mem_bytes > small_gpu.memory):
+      not small_gpu
+      or gpu_mem_usages[small_gpu.index] + small_gpu_mem_bytes > small_gpu.memory
+    ):
       raise ResourceLimitError(
         f"small gpu memory request of {small_gpu_mem_bytes} will exceed limit of "
         f"{small_gpu.memory if small_gpu else 0.0}")

--- a/lib/resource_manager.py
+++ b/lib/resource_manager.py
@@ -160,10 +160,8 @@ class ResourceManager():
     # Pick the candidate node with the lowest CPU usage
     numa_node = min(candidate_nodes, key=lambda node: cpu_usages[node] / self.cpu_totals[node])
 
-    if small_gpu_mem_bytes and (
-      not small_gpu
-      or gpu_mem_usages[small_gpu.index] + small_gpu_mem_bytes > small_gpu.memory
-    ):
+    small_gpu_over_limit = not small_gpu or gpu_mem_usages[small_gpu.index] + small_gpu_mem_bytes > small_gpu.memory
+    if small_gpu_mem_bytes and small_gpu_over_limit:
       raise ResourceLimitError(
         f"small gpu memory request of {small_gpu_mem_bytes} will exceed limit of "
         f"{small_gpu.memory if small_gpu else 0.0}")

--- a/lib/resource_manager.py
+++ b/lib/resource_manager.py
@@ -143,17 +143,18 @@ class ResourceManager():
 
     if limits.triton and self._triton_client is None:
       raise ResourceLimitError("Triton client is not available for this ResourceManager")
-    candidate_nodes = [
-      node for node in self.cpu_totals
-      if limits.cpu_threads <= self.cpu_totals[node] - cpu_usages[node]
-    ]
+    candidate_nodes = []
+    for node in self.cpu_totals:
+      if limits.cpu_threads <= self.cpu_totals[node] - cpu_usages[node]:
+        candidate_nodes.append(node)
     if not candidate_nodes:
       raise ResourceLimitError(
         f"CPU request of {limits.cpu_threads} will exceed limit of {sum(self.cpu_totals.values())}")
-    candidate_nodes = [
-      node for node in candidate_nodes
-      if (mem_bytes) <= self.mem_totals[node] - mem_usages[node]
-    ]
+    mem_ok_nodes = []
+    for node in candidate_nodes:
+      if (mem_bytes) <= self.mem_totals[node] - mem_usages[node]:
+        mem_ok_nodes.append(node)
+    candidate_nodes = mem_ok_nodes
     if not candidate_nodes:
       raise ResourceLimitError(f"memory request of {mem_bytes} will exceed limit of {sum(self.mem_totals.values())}")
     # Pick the candidate node with the lowest CPU usage

--- a/lib/resource_manager.py
+++ b/lib/resource_manager.py
@@ -199,12 +199,12 @@ class ResourceManager():
 
     cpu_usage = sum(cpu_usages.values()) / sum(self.cpu_totals.values())
     mem_usage = sum(mem_usages.values()) / sum(self.mem_totals.values())
-    small_gpu_mem_usage = sum(
-      gpu_mem_usages[gpu.index] for gpu in self.small_gpus
-    ) / (sum(gpu.memory for gpu in self.small_gpus) + 1e-5)
-    big_gpu_mem_usage = sum(
-      gpu_mem_usages[gpu.index] for gpu in self.big_gpus
-    ) / (sum(gpu.memory for gpu in self.big_gpus) + 1e-5)
+    small_gpu_mem_used = sum(gpu_mem_usages[gpu.index] for gpu in self.small_gpus)
+    small_gpu_mem_total = sum(gpu.memory for gpu in self.small_gpus) + 1e-5
+    small_gpu_mem_usage = small_gpu_mem_used / small_gpu_mem_total
+    big_gpu_mem_used = sum(gpu_mem_usages[gpu.index] for gpu in self.big_gpus)
+    big_gpu_mem_total = sum(gpu.memory for gpu in self.big_gpus) + 1e-5
+    big_gpu_mem_usage = big_gpu_mem_used / big_gpu_mem_total
     return cpu_usage, mem_usage, small_gpu_mem_usage, big_gpu_mem_usage
 
   def _get_cpu_info_by_node(self):

--- a/lib/resource_manager.py
+++ b/lib/resource_manager.py
@@ -66,7 +66,9 @@ class ResourceManager():
 
     if self.gpus:
       thread = threading.Thread(
-        target=check_gpu_status_worker, args=([gpu.bus_id for gpu in self.gpus], self.gpu_status))
+        target=check_gpu_status_worker,
+        args=([gpu.bus_id for gpu in self.gpus], self.gpu_status),
+      )
       thread.daemon = True
       thread.start()
 

--- a/lib/resource_manager.py
+++ b/lib/resource_manager.py
@@ -22,7 +22,7 @@ def check_gpu_status_worker(gpu_bus_ids, output):
     try:
       for bus_id in gpu_bus_ids:
         gpu_dev = pynvml.nvmlDeviceGetHandleByPciBusId(bus_id)
-        pynvml.nvmlDeviceGetTemperature(gpu_dev, pynvml.NVML_TEMPERATURE_GPU)  # sometimes we need to actually query the gpu to tell if it's fallen off
+        pynvml.nvmlDeviceGetTemperature(gpu_dev, pynvml.NVML_TEMPERATURE_GPU)  # query to tell if it's fallen off
       output.valid = True
     except pynvml.NVMLError:
       output.valid = False
@@ -65,7 +65,8 @@ class ResourceManager():
     self.gpu_locked_job: str | None = None
 
     if self.gpus:
-      thread = threading.Thread(target=check_gpu_status_worker, args=([gpu.bus_id for gpu in self.gpus], self.gpu_status))
+      thread = threading.Thread(
+        target=check_gpu_status_worker, args=([gpu.bus_id for gpu in self.gpus], self.gpu_status))
       thread.daemon = True
       thread.start()
 
@@ -134,24 +135,37 @@ class ResourceManager():
 
     big_gpu, small_gpu = None, None
     if big_gpu_mem_bytes > 0 and self.big_gpus:
-      big_gpu = min(self.big_gpus, key=lambda gpu: gpu_mem_usages[gpu.index])  # Pick the GPU with the lowest memory usage
+      big_gpu = min(self.big_gpus, key=lambda gpu: gpu_mem_usages[gpu.index])  # lowest memory usage
     if small_gpu_mem_bytes > 0 and (self.small_gpus or self.big_gpus):
-      small_gpu = min(self.small_gpus or self.big_gpus, key=lambda gpu: gpu_mem_usages[gpu.index])  # Fall back to big GPUs if no small ones are available
+      small_gpu = min(self.small_gpus or self.big_gpus, key=lambda gpu: gpu_mem_usages[gpu.index])  # fall back
 
     if limits.triton and self._triton_client is None:
       raise ResourceLimitError("Triton client is not available for this ResourceManager")
-    candidate_nodes = [node for node in self.cpu_totals if limits.cpu_threads <= self.cpu_totals[node] - cpu_usages[node]]
+    candidate_nodes = [
+      node for node in self.cpu_totals
+      if limits.cpu_threads <= self.cpu_totals[node] - cpu_usages[node]
+    ]
     if not candidate_nodes:
-      raise ResourceLimitError(f"CPU request of {limits.cpu_threads} will exceed limit of {sum(self.cpu_totals.values())}")
-    candidate_nodes = [node for node in candidate_nodes if (mem_bytes) <= self.mem_totals[node] - mem_usages[node]]
+      raise ResourceLimitError(
+        f"CPU request of {limits.cpu_threads} will exceed limit of {sum(self.cpu_totals.values())}")
+    candidate_nodes = [
+      node for node in candidate_nodes
+      if (mem_bytes) <= self.mem_totals[node] - mem_usages[node]
+    ]
     if not candidate_nodes:
       raise ResourceLimitError(f"memory request of {mem_bytes} will exceed limit of {sum(self.mem_totals.values())}")
-    numa_node = min(candidate_nodes, key=lambda node: cpu_usages[node] / self.cpu_totals[node])  # Pick the candidate node with the lowest CPU usage
+    # Pick the candidate node with the lowest CPU usage
+    numa_node = min(candidate_nodes, key=lambda node: cpu_usages[node] / self.cpu_totals[node])
 
-    if small_gpu_mem_bytes and (not small_gpu or gpu_mem_usages[small_gpu.index] + small_gpu_mem_bytes > small_gpu.memory):
-      raise ResourceLimitError(f"small gpu memory request of {small_gpu_mem_bytes} will exceed limit of {small_gpu.memory if small_gpu else 0.0}")
+    if small_gpu_mem_bytes and (
+      not small_gpu or gpu_mem_usages[small_gpu.index] + small_gpu_mem_bytes > small_gpu.memory):
+      raise ResourceLimitError(
+        f"small gpu memory request of {small_gpu_mem_bytes} will exceed limit of "
+        f"{small_gpu.memory if small_gpu else 0.0}")
     if big_gpu_mem_bytes and (not big_gpu or gpu_mem_usages[big_gpu.index] + big_gpu_mem_bytes > big_gpu.memory):
-      raise ResourceLimitError(f"big gpu memory request of {big_gpu_mem_bytes} will exceed limit of {big_gpu.memory if big_gpu else 0.0}")
+      raise ResourceLimitError(
+        f"big gpu memory request of {big_gpu_mem_bytes} will exceed limit of "
+        f"{big_gpu.memory if big_gpu else 0.0}")
 
     # Store allocation (no exceptions should be raised below this line)
     if self.gpu_locked_job != job and limits.requires_gpu():
@@ -180,8 +194,12 @@ class ResourceManager():
 
     cpu_usage = sum(cpu_usages.values()) / sum(self.cpu_totals.values())
     mem_usage = sum(mem_usages.values()) / sum(self.mem_totals.values())
-    small_gpu_mem_usage = sum(gpu_mem_usages[gpu.index] for gpu in self.small_gpus) / (sum(gpu.memory for gpu in self.small_gpus) + 1e-5)
-    big_gpu_mem_usage = sum(gpu_mem_usages[gpu.index] for gpu in self.big_gpus) / (sum(gpu.memory for gpu in self.big_gpus) + 1e-5)
+    small_gpu_mem_usage = sum(
+      gpu_mem_usages[gpu.index] for gpu in self.small_gpus
+    ) / (sum(gpu.memory for gpu in self.small_gpus) + 1e-5)
+    big_gpu_mem_usage = sum(
+      gpu_mem_usages[gpu.index] for gpu in self.big_gpus
+    ) / (sum(gpu.memory for gpu in self.big_gpus) + 1e-5)
     return cpu_usage, mem_usage, small_gpu_mem_usage, big_gpu_mem_usage
 
   def _get_cpu_info_by_node(self):

--- a/lib/triton_helpers.py
+++ b/lib/triton_helpers.py
@@ -34,9 +34,16 @@ def _is_model_loading(client: InferenceServerClient, model_name: str):
       return True
   return False
 
-check_triton_server_health = retry(stop=stop_after_delay(15), wait=wait_fixed(1), reraise=True)(
-  _check_triton_server_health)
-wait_for_triton_server = retry(stop=stop_after_delay(60), wait=wait_fixed(2), reraise=True)(_check_triton_server_health)
+check_triton_server_health = retry(
+  stop=stop_after_delay(15),
+  wait=wait_fixed(1),
+  reraise=True,
+)(_check_triton_server_health)
+wait_for_triton_server = retry(
+  stop=stop_after_delay(60),
+  wait=wait_fixed(2),
+  reraise=True,
+)(_check_triton_server_health)
 
 @retry(stop=stop_after_attempt(3), wait=wait_random(1, 2), reraise=True)
 def get_triton_inference_stats(client: InferenceServerClient):

--- a/lib/triton_helpers.py
+++ b/lib/triton_helpers.py
@@ -34,7 +34,8 @@ def _is_model_loading(client: InferenceServerClient, model_name: str):
       return True
   return False
 
-check_triton_server_health = retry(stop=stop_after_delay(15), wait=wait_fixed(1), reraise=True)(_check_triton_server_health)
+check_triton_server_health = retry(stop=stop_after_delay(15), wait=wait_fixed(1), reraise=True)(
+  _check_triton_server_health)
 wait_for_triton_server = retry(stop=stop_after_delay(60), wait=wait_fixed(2), reraise=True)(_check_triton_server_health)
 
 @retry(stop=stop_after_attempt(3), wait=wait_random(1, 2), reraise=True)
@@ -53,7 +54,9 @@ def load_triton_model(client: InferenceServerClient, model: str, config: ModelCo
 
 def setup_triton_model(func: Callable[..., ModelConfig]):
   @wraps(func)
-  def wrapper(*self: Any, client: InferenceServerClient, model: str, redis: Optional[StrictRedis] = None, load_timeout = 60) -> None:
+  def wrapper(
+    *self: Any, client: InferenceServerClient, model: str, redis: Optional[StrictRedis] = None, load_timeout = 60,
+  ) -> None:
       model_dir = TRITON_MODEL_REPOSITORY / model / '1'
       if client.is_model_ready(model):  # if the model is already loaded, bump the mtime and return
         mtime = time.time()
@@ -103,13 +106,15 @@ def kill_triton_processes_by_name(name: str) -> None:
     try: os.kill(int(pid_text), signal.SIGKILL)
     except ProcessLookupError: pass
 
-# NOTE: This function must also run as root, since the triton_python_backend_shm_region files are created directly by the triton server
+# NOTE: This function must also run as root, since the triton_python_backend_shm_region files are
+# created directly by the triton server
 def unlink_triton_shm_files() -> None:
   for f in Path("/dev/shm").glob("triton_python_backend_shm_region_*"):
     f.unlink(missing_ok=True)
 
 def get_triton_container_id() -> str:
-  container_ids = subprocess.check_output(["docker", "ps", "--format", "{{.ID}}", "--filter", "name=tritonserver"]).decode('utf-8').strip()
+  container_ids = subprocess.check_output(
+    ["docker", "ps", "--format", "{{.ID}}", "--filter", "name=tritonserver"]).decode('utf-8').strip()
   if not container_ids:
     raise RuntimeError("No tritonserver container found")
   return container_ids.split('\n')[0]
@@ -127,8 +132,10 @@ def unload_stale_models(triton_client: InferenceServerClient, redis_client: Stri
     except FileNotFoundError: model_mtime = 0
     try: parameters = triton_client.get_model_config(model['name']).get('parameters', {})
     except InferenceServerException: continue
-    model_stale_after_seconds = float(parameters.get(TRITON_MODEL_STALE_AFTER_SECONDS_PARAMETER, {}).get('string_value', 60))
-    if model['name'] != keep_model_name and time.time() - max(last_inference_time, model_mtime) > model_stale_after_seconds:
+    model_stale_after_seconds = float(
+      parameters.get(TRITON_MODEL_STALE_AFTER_SECONDS_PARAMETER, {}).get('string_value', 60))
+    if model['name'] != keep_model_name and (
+      time.time() - max(last_inference_time, model_mtime) > model_stale_after_seconds):
       with redis_client.lock(model['name'], timeout=60):
         unload_triton_model(triton_client, model['name'])
 

--- a/lib/triton_helpers.py
+++ b/lib/triton_helpers.py
@@ -61,13 +61,11 @@ def load_triton_model(client: InferenceServerClient, model: str, config: ModelCo
 
 def setup_triton_model(func: Callable[..., ModelConfig]):
   @wraps(func)
-  def wrapper(
-    *self: Any,
+  def wrapper(*self: Any,
     client: InferenceServerClient,
     model: str,
     redis: Optional[StrictRedis] = None,
-    load_timeout = 60,
-  ) -> None:
+    load_timeout = 60) -> None:
       model_dir = TRITON_MODEL_REPOSITORY / model / '1'
       if client.is_model_ready(model):  # if the model is already loaded, bump the mtime and return
         mtime = time.time()

--- a/lib/triton_helpers.py
+++ b/lib/triton_helpers.py
@@ -62,7 +62,11 @@ def load_triton_model(client: InferenceServerClient, model: str, config: ModelCo
 def setup_triton_model(func: Callable[..., ModelConfig]):
   @wraps(func)
   def wrapper(
-    *self: Any, client: InferenceServerClient, model: str, redis: Optional[StrictRedis] = None, load_timeout = 60,
+    *self: Any,
+    client: InferenceServerClient,
+    model: str,
+    redis: Optional[StrictRedis] = None,
+    load_timeout = 60,
   ) -> None:
       model_dir = TRITON_MODEL_REPOSITORY / model / '1'
       if client.is_model_ready(model):  # if the model is already loaded, bump the mtime and return

--- a/lib/uv.py
+++ b/lib/uv.py
@@ -31,7 +31,9 @@ def sync_venv_cache(codedir: Union[str, Path], user_id: int, venv_name: str):
   errs = []
   for i in range(N_RETRIES):
     try:
-      subprocess.run(sync_cmd, env={**os.environ, 'UV_PROJECT_ENVIRONMENT': str(venv_dir)}, user=user_id, check=True, capture_output=True)
+      subprocess.run(
+        sync_cmd, env={**os.environ, 'UV_PROJECT_ENVIRONMENT': str(venv_dir)},
+        user=user_id, check=True, capture_output=True)
       return venv_dir
     except subprocess.CalledProcessError as e:
       errs.append(f'try {i}: {parse_uv_sync_stderr(e.stderr)}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ testpaths = ["tests"]
 [tool.ruff]
 lint.select = ["A", "B", "E", "F", "N", "W", "PIE", "C4", "ISC", "RUF100", "PTH", "TID251", "SLF"]
 lint.ignore = ["E701"]
-line-length = 160
+line-length = 120
 target-version="py312"
 exclude = ["miniray"]
 

--- a/tests/dstate_helpers.py
+++ b/tests/dstate_helpers.py
@@ -28,7 +28,8 @@ def block_in_frozen_filesystem(hold_seconds: int):
   def cleanup_mount():
     subprocess.run(["fsfreeze", "-u", str(mnt)], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     for _ in range(100):
-      if subprocess.run(["umount", str(mnt)], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0:
+      if subprocess.run(["umount", str(mnt)], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                         ).returncode == 0:
         break
       time.sleep(0.1)
     shutil.rmtree(tmp_root, ignore_errors=True)

--- a/worker.py
+++ b/worker.py
@@ -590,8 +590,12 @@ def main():
       job_keys = [key.decode() for key in all_keys if b":" not in key]
       jobs = sorted(job_keys)[:JOB_CACHE_SIZE]
       update_job_metadatas(r_master, jobs, job_metadatas, job_errors)
-      jobs = [j for j in jobs if not job_metadatas[j].limits.get('node_whitelist')
-              or HOST_NAME in job_metadatas[j].limits['node_whitelist']]
+      filtered_jobs = []
+      for j in jobs:
+        whitelist = job_metadatas[j].limits.get('node_whitelist')
+        if not whitelist or HOST_NAME in whitelist:
+          filtered_jobs.append(j)
+      jobs = filtered_jobs
       current_gpu_job = get_globally_scheduled_job(r_master, jobs, job_metadatas)
       timings['redis_sched'] = time.perf_counter() - t0
 

--- a/worker.py
+++ b/worker.py
@@ -406,9 +406,8 @@ def get_job_intervals(raw_weights: list[int], n_workers: int) -> list[float]:
 #   Divide by N to get a point P in [0, 1).
 # - Divide the interval [0, 1] amongst the available jobs, weighted by job priority
 # - Find the job whose interval contains P, this will be the job we accept.
-def get_globally_scheduled_job(
-  r_master: StrictRedis, jobs: list[str], job_metadatas: LRU[str, JobMetadata],
-) -> Optional[str]:
+def get_globally_scheduled_job(r_master: StrictRedis,
+  jobs: list[str], job_metadatas: LRU[str, JobMetadata]) -> Optional[str]:
   # we use the hash so machines with different compute capabilities are evenly distributed
   active_key = hashlib.md5(ACTIVE_KEY.encode()).hexdigest()
   active_worker_keys = cast(list[bytes], r_master.keys(f"active:{PIPELINE_QUEUE}:*"))
@@ -432,10 +431,8 @@ def get_randomly_scheduled_job(jobs: list[str], job_metadatas: LRU[str, JobMetad
   job = random.choices(jobs, weights=job_weights, k=1)[0]
   return job
 
-def update_job_metadatas(
-  r_master: StrictRedis, jobs: list[str], job_metadatas: LRU[str, JobMetadata],
-  job_errors: LRU[str, tuple[str, str] | None],
-):
+def update_job_metadatas(r_master: StrictRedis, jobs: list[str],
+  job_metadatas: LRU[str, JobMetadata], job_errors: LRU[str, tuple[str, str] | None]):
   for job in set(job_metadatas.keys()) - set(jobs):
     del job_metadatas[job]
     job_errors.pop(job, None)
@@ -452,12 +449,10 @@ def update_job_metadatas(
         job_metadatas[job] = JobMetadata(False, 1, "", "", Limits().asdict(), {})
         job_errors[job] = ("JobMetadataError", f"{job}: {desc(e)}")
 
-def get_task(
-  resource_manager: ResourceManager, r_master: StrictRedis,
+def get_task(resource_manager: ResourceManager, r_master: StrictRedis,
   r_results: StrictRedis, r_claimed: StrictRedis, job: str,
   job_metadatas: LRU[str, JobMetadata], job_errors: LRU[str, tuple[str, str] | None],
-  venvs: LRU[str, str], proc_index: int, triton_client,
-) -> Optional[Task]:
+  venvs: LRU[str, str], proc_index: int, triton_client) -> Optional[Task]:
   limits = Limits(**job_metadatas[job].limits)
   temp_key = f"{job}-pending"
   try:

--- a/worker.py
+++ b/worker.py
@@ -28,15 +28,21 @@ from redis import StrictRedis
 from typing import BinaryIO, Optional, cast
 from tritonclient.http import InferenceServerClient
 
-from miniray.lib.cgroup import cgroup_create, cgroup_set_subcontrollers, cgroup_set_memory_limit, \
-                               cgroup_set_numa_nodes, cgroup_add_pid, cgroup_kill, cgroup_delete, cgroup_clear_all_children, cgroup_is_populated
+from miniray.lib.cgroup import (
+  cgroup_create, cgroup_set_subcontrollers, cgroup_set_memory_limit, cgroup_set_numa_nodes,
+  cgroup_add_pid, cgroup_kill, cgroup_delete, cgroup_clear_all_children, cgroup_is_populated,
+)
 from miniray.lib.sig_term_handler import SigTermHandler
 from miniray.lib.resource_manager import ResourceManager, ResourceLimitError
 from miniray.lib.worker_helpers import ExponentialBackoff
 from miniray.lib.triton_helpers import TRITON_SERVER_ADDRESS, check_triton_server_health, wait_for_triton_server
-from miniray.lib.system_helpers import get_cgroup_cpu_usage, get_cgroup_mem_usage, get_gpu_stats, get_gpu_mem_usage, get_gpu_utilization
+from miniray.lib.system_helpers import (
+  get_cgroup_cpu_usage, get_cgroup_mem_usage, get_gpu_stats, get_gpu_mem_usage, get_gpu_utilization,
+)
 from miniray.lib.statsd_helpers import statsd
-from miniray.lib.helpers import Limits, desc, GB_TO_BYTES, MAX_WORKER_LOOP_SECONDS, TASK_TIMEOUT_GRACE_SECONDS, JOB_CACHE_SIZE
+from miniray.lib.helpers import (
+  Limits, desc, GB_TO_BYTES, MAX_WORKER_LOOP_SECONDS, TASK_TIMEOUT_GRACE_SECONDS, JOB_CACHE_SIZE,
+)
 from miniray.lib.uv import sync_venv_cache, cleanup_venvs, populate_venv_cache_from_disk, pycache_dir_for_venv
 from miniray.executor import MinirayResultHeader, JobMetadata, TaskRecord, TaskState, get_metadata_key, get_tasks_key
 
@@ -236,8 +242,9 @@ class Task:
       if DEBUG: print("[worker]", " ".join(p_args))
 
       t0 = time.perf_counter()
-      self.proc = subprocess.Popen(p_args, user=TASK_UID, group=self.task_gid, extra_groups=task_extra_groups, cwd=str(EMPTY_DIR), env=p_env,
-                                   start_new_session=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      self.proc = subprocess.Popen(
+        p_args, user=TASK_UID, group=self.task_gid, extra_groups=task_extra_groups, cwd=str(EMPTY_DIR), env=p_env,
+        start_new_session=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
       cgroup_add_pid(self.cgroup_name, self.proc.pid)
       assert self.proc.stdin is not None
       stdin = cast(BinaryIO, self.proc.stdin)
@@ -325,8 +332,9 @@ class Task:
       task_gpu_time = get_gpu_utilization(task_gpu_stats) * task_run_time
       task_memory_gb = get_cgroup_mem_usage(self.cgroup_name) * 1e-9
       task_gpu_memory_gb = get_gpu_mem_usage(task_gpu_stats) * 1e-9
-      statsd.event("pipeline.worker.task_done", runtime=task_run_time, cpu=task_cpu_time, gpu=task_gpu_time,
-                                                memory=task_memory_gb, gpu_memory=task_gpu_memory_gb, tags={'task_id': self.job})
+      statsd.event(
+        "pipeline.worker.task_done", runtime=task_run_time, cpu=task_cpu_time, gpu=task_gpu_time,
+        memory=task_memory_gb, gpu_memory=task_gpu_memory_gb, tags={'task_id': self.job})
       print(f"[worker] finished miniray task from job {self.job} stats: "
             f"elapsed={task_run_time:0.2f}s cpu={task_cpu_time:0.2f}s gpu={task_gpu_time:0.2f}s "
             f"mem={task_memory_gb:0.2f}GB gpumem={task_gpu_memory_gb:0.2f}GB")
@@ -382,11 +390,11 @@ class Task:
 # For example: if we have weights [1, 100, 1000] and N = 10, we find x = 1250
 # to get weights = [0.1, 0.1, 0.8], which satisfies all(W >= 1 / N) and sum(W) == 1.
 def get_job_intervals(raw_weights: list[int], n_workers: int) -> list[float]:
-  weights = all_weights = np.array(raw_weights[:n_workers])  # we have N workers, so we can only schedule a maximum of N jobs at once
+  weights = all_weights = np.array(raw_weights[:n_workers])  # max of N jobs at once
   x = 0
   while sum(weights) / n_workers > x + 1e-7:  # small epsilon to fix rounding errors
     x = sum(weights) / n_workers  # set x to its lower bound
-    n_workers -= sum(weights / x < 1)  # any weights less than 1 / N will be clamped, so remove these weights from both N and weights and keep looping
+    n_workers -= sum(weights / x < 1)  # weights < 1/N get clamped, remove from N and weights
     weights = weights[weights / x >= 1]
 
   weights = np.maximum(1, all_weights / x)
@@ -394,12 +402,17 @@ def get_job_intervals(raw_weights: list[int], n_workers: int) -> list[float]:
   return weights.tolist()
 
 # To decide which job to accept, we do the following:
-# - Find our position in the sorted list of N active workers, this will be a number in [0, N). Divide by N to get a point P in [0, 1).
+# - Find our position in the sorted list of N active workers, this will be a number in [0, N).
+#   Divide by N to get a point P in [0, 1).
 # - Divide the interval [0, 1] amongst the available jobs, weighted by job priority
 # - Find the job whose interval contains P, this will be the job we accept.
-def get_globally_scheduled_job(r_master: StrictRedis, jobs: list[str], job_metadatas: LRU[str, JobMetadata]) -> Optional[str]:
-  active_key = hashlib.md5(ACTIVE_KEY.encode()).hexdigest()  # we use the hash so machines with different compute capabilities are evenly distributed
-  active_workers = sorted(hashlib.md5(k).hexdigest() for k in cast(list[bytes], r_master.keys(f"active:{PIPELINE_QUEUE}:*")))
+def get_globally_scheduled_job(
+  r_master: StrictRedis, jobs: list[str], job_metadatas: LRU[str, JobMetadata],
+) -> Optional[str]:
+  # we use the hash so machines with different compute capabilities are evenly distributed
+  active_key = hashlib.md5(ACTIVE_KEY.encode()).hexdigest()
+  active_workers = sorted(
+    hashlib.md5(k).hexdigest() for k in cast(list[bytes], r_master.keys(f"active:{PIPELINE_QUEUE}:*")))
   if not jobs or active_key not in active_workers:
     return None
 
@@ -419,7 +432,10 @@ def get_randomly_scheduled_job(jobs: list[str], job_metadatas: LRU[str, JobMetad
   job = random.choices(jobs, weights=job_weights, k=1)[0]
   return job
 
-def update_job_metadatas(r_master: StrictRedis, jobs: list[str], job_metadatas: LRU[str, JobMetadata], job_errors: LRU[str, tuple[str, str] | None]):
+def update_job_metadatas(
+  r_master: StrictRedis, jobs: list[str], job_metadatas: LRU[str, JobMetadata],
+  job_errors: LRU[str, tuple[str, str] | None],
+):
   for job in set(job_metadatas.keys()) - set(jobs):
     del job_metadatas[job]
     job_errors.pop(job, None)
@@ -436,9 +452,12 @@ def update_job_metadatas(r_master: StrictRedis, jobs: list[str], job_metadatas: 
         job_metadatas[job] = JobMetadata(False, 1, "", "", Limits().asdict(), {})
         job_errors[job] = ("JobMetadataError", f"{job}: {desc(e)}")
 
-def get_task(resource_manager: ResourceManager, r_master: StrictRedis,
-             r_results: StrictRedis, r_claimed: StrictRedis, job: str, job_metadatas: LRU[str, JobMetadata], job_errors: LRU[str, tuple[str, str] | None],
-             venvs: LRU[str, str], proc_index: int, triton_client) -> Optional[Task]:
+def get_task(
+  resource_manager: ResourceManager, r_master: StrictRedis,
+  r_results: StrictRedis, r_claimed: StrictRedis, job: str,
+  job_metadatas: LRU[str, JobMetadata], job_errors: LRU[str, tuple[str, str] | None],
+  venvs: LRU[str, str], proc_index: int, triton_client,
+) -> Optional[Task]:
   limits = Limits(**job_metadatas[job].limits)
   temp_key = f"{job}-pending"
   try:
@@ -472,7 +491,9 @@ def get_task(resource_manager: ResourceManager, r_master: StrictRedis,
 
   resource_manager.rekey(temp_key, record.uuid)
 
-  return Task(record, limits, proc_index, resource_manager, r_master, r_results, job_metadatas[job], job_errors.get(job), venvs, triton_client)
+  return Task(
+    record, limits, proc_index, resource_manager, r_master, r_results,
+    job_metadatas[job], job_errors.get(job), venvs, triton_client)
 
 
 def sig_callback(signal):
@@ -564,10 +585,13 @@ def main():
       timings['triton'] = time.perf_counter() - worker_loop_start
 
       t0 = time.perf_counter()
-      # TODO: with >JOB_CACHE_SIZE jobs, this drops the tail of the sorted list, so prioritization is broken and the excluded jobs get no share
-      jobs = sorted(key.decode() for key in cast(list[bytes], r_master.keys(f"*{PIPELINE_QUEUE}")) if b":" not in key)[:JOB_CACHE_SIZE]
+      # TODO: with >JOB_CACHE_SIZE jobs, this drops the tail of the sorted list, so prioritization is broken
+      jobs = sorted(
+        key.decode() for key in cast(list[bytes], r_master.keys(f"*{PIPELINE_QUEUE}")) if b":" not in key
+      )[:JOB_CACHE_SIZE]
       update_job_metadatas(r_master, jobs, job_metadatas, job_errors)
-      jobs = [j for j in jobs if not job_metadatas[j].limits.get('node_whitelist') or HOST_NAME in job_metadatas[j].limits['node_whitelist']]
+      jobs = [j for j in jobs if not job_metadatas[j].limits.get('node_whitelist')
+              or HOST_NAME in job_metadatas[j].limits['node_whitelist']]
       current_gpu_job = get_globally_scheduled_job(r_master, jobs, job_metadatas)
       timings['redis_sched'] = time.perf_counter() - t0
 
@@ -575,7 +599,10 @@ def main():
 
       for i, proc in procs.items():
         if time.perf_counter() - worker_loop_start > MAX_WORKER_LOOP_SECONDS:
-          start_breakdown = ", ".join(f"{k}={v:.2f}s" for k, v in sorted(last_init_timings.items(), key=lambda x: -x[1])) if last_init_timings else "n/a"
+          sorted_timings = sorted(last_init_timings.items(), key=lambda x: -x[1])
+          start_breakdown = ", ".join(
+            f"{k}={v:.2f}s" for k, v in sorted_timings
+          ) if last_init_timings else "n/a"
           print("[worker] loop breakdown: " +
                 ", ".join(f"{k}={v:.2f}s" for k, v in sorted(timings.items(), key=lambda x: -x[1]) if v > 0.01) +
                 f" | last start_task: {start_breakdown}")
@@ -599,7 +626,8 @@ def main():
         task = None
         if current_gpu_job is not None and current_gpu_job in venvs:
           t0 = time.perf_counter()
-          task = get_task(rm, r_master, r_results, r_claimed, current_gpu_job, job_metadatas, job_errors, venvs, i, triton_client)
+          task = get_task(
+            rm, r_master, r_results, r_claimed, current_gpu_job, job_metadatas, job_errors, venvs, i, triton_client)
           timings['get_task'] += time.perf_counter() - t0
         if task is None:
           ready_jobs = [j for j in jobs if j in venvs]

--- a/worker.py
+++ b/worker.py
@@ -411,8 +411,8 @@ def get_globally_scheduled_job(
 ) -> Optional[str]:
   # we use the hash so machines with different compute capabilities are evenly distributed
   active_key = hashlib.md5(ACTIVE_KEY.encode()).hexdigest()
-  active_workers = sorted(
-    hashlib.md5(k).hexdigest() for k in cast(list[bytes], r_master.keys(f"active:{PIPELINE_QUEUE}:*")))
+  active_worker_keys = cast(list[bytes], r_master.keys(f"active:{PIPELINE_QUEUE}:*"))
+  active_workers = sorted(hashlib.md5(k).hexdigest() for k in active_worker_keys)
   if not jobs or active_key not in active_workers:
     return None
 
@@ -586,9 +586,9 @@ def main():
 
       t0 = time.perf_counter()
       # TODO: with >JOB_CACHE_SIZE jobs, this drops the tail of the sorted list, so prioritization is broken
-      jobs = sorted(
-        key.decode() for key in cast(list[bytes], r_master.keys(f"*{PIPELINE_QUEUE}")) if b":" not in key
-      )[:JOB_CACHE_SIZE]
+      all_keys = cast(list[bytes], r_master.keys(f"*{PIPELINE_QUEUE}"))
+      job_keys = [key.decode() for key in all_keys if b":" not in key]
+      jobs = sorted(job_keys)[:JOB_CACHE_SIZE]
       update_job_metadatas(r_master, jobs, job_metadatas, job_errors)
       jobs = [j for j in jobs if not job_metadatas[j].limits.get('node_whitelist')
               or HOST_NAME in job_metadatas[j].limits['node_whitelist']]
@@ -600,12 +600,10 @@ def main():
       for i, proc in procs.items():
         if time.perf_counter() - worker_loop_start > MAX_WORKER_LOOP_SECONDS:
           sorted_timings = sorted(last_init_timings.items(), key=lambda x: -x[1])
-          start_breakdown = ", ".join(
-            f"{k}={v:.2f}s" for k, v in sorted_timings
-          ) if last_init_timings else "n/a"
-          print("[worker] loop breakdown: " +
-                ", ".join(f"{k}={v:.2f}s" for k, v in sorted(timings.items(), key=lambda x: -x[1]) if v > 0.01) +
-                f" | last start_task: {start_breakdown}")
+          start_breakdown = ", ".join(f"{k}={v:.2f}s" for k, v in sorted_timings) if last_init_timings else "n/a"
+          sorted_loop = sorted(((k, v) for k, v in timings.items() if v > 0.01), key=lambda x: -x[1])
+          loop_breakdown = ", ".join(f"{k}={v:.2f}s" for k, v in sorted_loop)
+          print(f"[worker] loop breakdown: {loop_breakdown} | last start_task: {start_breakdown}")
           raise RuntimeError("Did not loop over processes fast enough, cannot garantuee task integrity")
 
         if proc:


### PR DESCRIPTION
Lowers the ruff `line-length` from 160 to 120 and wraps the lines that exceed it. No logic changes — just line wrapping to stay under the new limit. 2-space indentation is preserved (no formatter run).